### PR TITLE
end_round(): Pass turn back to the original leader when there is no surpass.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 src/DevTools.lua
+.tts/

--- a/src/BaseGame.lua
+++ b/src/BaseGame.lua
@@ -239,6 +239,7 @@ function BaseGame.setup(with_leaders, with_ll_expansion)
         BaseGame.setupPlayers(active_players, chosen_setup_card)
     end
 
+    Turns.turn_color = active_players[1].color
     Turns.enable = true;
 
     return true

--- a/src/Campaign.lua
+++ b/src/Campaign.lua
@@ -130,6 +130,7 @@ function Campaign.setup(with_leaders, with_ll_expansion)
         Campaign.dealPlayerFates()
     end, 5)
 
+    Turns.turn_color = active_players[1].color
     Turns.enable = true;
 
     return true

--- a/src/Control.lua
+++ b/src/Control.lua
@@ -137,6 +137,7 @@ function end_round()
     else
         local surpassing = ActionCards.get_surpassing_card()
         if (surpassing == nil) then
+            Turns.turn_color = Initiative.player
             return
         end
         local surpass_name = surpassing.type .. " " ..

--- a/src/Control.lua
+++ b/src/Control.lua
@@ -126,7 +126,7 @@ function start_chapter()
     ActionCards.deal_hand()
 
     local initiative_player = Global.getVar("initiative_player")
-    broadcastToAll(initiative_player .. " will start the chapter", initiative_player)
+    broadcastToAll(initiative_player .. " will start the chapter\n", initiative_player)
     Turns.turn_color = initiative_player
 end
 
@@ -139,7 +139,6 @@ function end_round()
     if (Initiative.is_seized()) then
         Initiative.unseize()
         Turns.turn_color = initiative_player
-        broadcastToAll(initiative_player .. " had seized initiative", initiative_player)
     else
         local surpassing = ActionCards.get_surpassing_card()
         if not surpassing then

--- a/src/Control.lua
+++ b/src/Control.lua
@@ -124,21 +124,28 @@ function start_chapter()
     end
 
     ActionCards.deal_hand()
+
+    local initiative_player = Global.getVar("initiative_player")
+    print(initiative_player .. " will start the chapter", initiative_player)
+    Turns.turn_color = initiative_player
 end
 
 function end_round()
     ActionCards.clear_played()
     AmbitionMarkers.reset_zero_marker()
+    local initiative_player = Global.getVar("initiative_player")
 
     -- Auto Initiative, Find surpassing card
     if (Initiative.is_seized()) then
         Initiative.unseize()
-        Turns.turn_color = Initiative.player
+        Turns.turn_color = initiative_player
+        broadcastToAll(initiative_player .. " had seized initiative", initiative_player)
     else
         local surpassing = ActionCards.get_surpassing_card()
         if not surpassing then
-            Turns.turn_color = Initiative.player
-            return
+            Turns.turn_color = initiative_player
+            broadcastToAll("No surpass or seize, ".. initiative_player .. " keeps initiative.", initiative_player)
+
         else
             local all_players = Global.getVar("active_players")
             for _, p in ipairs(all_players) do
@@ -146,16 +153,17 @@ function end_round()
                    p.last_action_card.type == surpassing.type and
                    p.last_action_card.number == surpassing.number then
                     Initiative.unseize()
-                    Initiative.take(p.color)
+                    Initiative.take(p.color, true)
                     Turns.turn_color = p.color
                     p.last_action_card = nil
+                    broadcastToAll(p.color .. " has surpassed and takes initiative.", p.color)
                     break
                 end
             end
         end
     end
 
-    broadcastToAll("End Round\n")
+    broadcastToAll("End Round\n", Color.Purple)
 end
 
 function take_initiative(objectButtonClicked, playerColorClicked)

--- a/src/Control.lua
+++ b/src/Control.lua
@@ -126,7 +126,7 @@ function start_chapter()
     ActionCards.deal_hand()
 
     local initiative_player = Global.getVar("initiative_player")
-    print(initiative_player .. " will start the chapter", initiative_player)
+    broadcastToAll(initiative_player .. " will start the chapter", initiative_player)
     Turns.turn_color = initiative_player
 end
 
@@ -145,7 +145,6 @@ function end_round()
         if not surpassing then
             Turns.turn_color = initiative_player
             broadcastToAll("No surpass or seize, ".. initiative_player .. " keeps initiative.", initiative_player)
-
         else
             local all_players = Global.getVar("active_players")
             for _, p in ipairs(all_players) do

--- a/src/Control.lua
+++ b/src/Control.lua
@@ -136,35 +136,26 @@ function end_round()
         Turns.turn_color = Initiative.player
     else
         local surpassing = ActionCards.get_surpassing_card()
-        if (surpassing == nil) then
+        if not surpassing then
             Turns.turn_color = Initiative.player
             return
-        end
-        local surpass_name = surpassing.type .. " " ..
-                                 tostring(surpassing.number)
-
-        local all_players = Global.getVar("active_players")
-        for _, p in ipairs(all_players) do
-            if (p.last_action_card) then
-                if (p.last_action_card.type == surpassing.type and
-                    p.last_action_card.number == surpassing.number) then
-
+        else
+            local all_players = Global.getVar("active_players")
+            for _, p in ipairs(all_players) do
+                if p.last_action_card and
+                   p.last_action_card.type == surpassing.type and
+                   p.last_action_card.number == surpassing.number then
                     Initiative.unseize()
                     Initiative.take(p.color)
-
                     Turns.turn_color = p.color
-
                     p.last_action_card = nil
-
-                    broadcastToAll("End Hand\n")
-                    return
+                    break
                 end
             end
         end
     end
 
-    broadcastToAll("End Hand\n")
-    return
+    broadcastToAll("End Round\n")
 end
 
 function take_initiative(objectButtonClicked, playerColorClicked)

--- a/src/InitiativeMarker.lua
+++ b/src/InitiativeMarker.lua
@@ -1,7 +1,7 @@
 require("src/GUIDs")
 
-local InitiativeMarker = {
-    player = nil
+InitiativeMarker = {
+    placeholder = nil
 }
 
 local initiative_pos = {-2, 0, -2.2}
@@ -33,11 +33,9 @@ function InitiativeMarker.unseize()
     if (initiative_seized) then
         initiative_seized.setState(1)
     end
-
-    InitiativeMarker.player = nil
 end
 
-function InitiativeMarker.take(player_color)
+function InitiativeMarker.take(player_color, silent)
     local initiative = getObjectFromGUID(initiative_GUID)
     local player_board = getObjectFromGUID(
         player_pieces_GUIDs[player_color]["player_board"])
@@ -45,13 +43,15 @@ function InitiativeMarker.take(player_color)
 
     if (initiative) then
         initiative.setPositionSmooth(pos)
-        broadcastToAll(player_color .. " takes initiative", player_color)
+        if not silent then
+            broadcastToAll(player_color .. " takes initiative", player_color)
+        end
     end
 
-    InitiativeMarker.player = player_color
+    Global.setVar("initiative_player", player_color)
 end
 
-function InitiativeMarker.seize(player_color)
+function InitiativeMarker.seize(player_color,  silent)
     local initiative = getObjectFromGUID(initiative_GUID)
     local player_board = getObjectFromGUID(
         player_pieces_GUIDs[player_color]["player_board"])
@@ -62,11 +62,13 @@ function InitiativeMarker.seize(player_color)
         Wait.time(function()
             initiative.setState(2)
         end, 1.5)
-        broadcastToAll(player_color .. " seizes initiative", player_color)
+        if not silent then
+            broadcastToAll(player_color .. " seizes initiative", player_color)
+        end
     else
         broadcastToAll("Initiative is already seized.", Color.Red)
     end
-    InitiativeMarker.player = player_color
+    Global.setVar("initiative_player", player_color)
 end
 
 return InitiativeMarker


### PR DESCRIPTION
I noticed that when only copies/pivots occur in a turn, and end_round is executed, turn order needed to be manually passed from the end player, back to the one who still holds the initiative.  This assists with that turn change.  Additionally while looking at the rest of the function, I noticed some unused + redundant logic.


This PR:

- Adds a gitignore for .tts folder
- Sets the starting player turn order based on whomever was assigned first initiative.  (Note that the game still possibly announces the first turn to a different color, but now quickly reassigns it to the expected player.  I've yet to track down why an incorrect player is first assigned when Turns.enable = true is applied.)
- Adjusts Control start_chapter() to broadcast who the starting player is with a newline at the end.
- Adjusts InitiativeMarker to setup a global variable for tracking who the initiative_player is. 
- Refines Control end_round() so that initiative is passed between players more consistently and cleans up the game state broadcasts for readability. 