### PR TITLE
[Bugfix] Resource:take only works at beginning of the game

### DIFF
--- a/src/Resource.lua
+++ b/src/Resource.lua
@@ -2,13 +2,12 @@ require("src/GUIDs")
 local LOG = require("src/LOG")
 
 local Resource = {
-    supplies = {
-        psionic = getObjectFromGUID(resources_GUID["psionics"]),
-        relic = getObjectFromGUID(resources_GUID["relics"]),
-        weapon = getObjectFromGUID(resources_GUID["weapons"]),
-        fuel = getObjectFromGUID(resources_GUID["fuel"]),
-        material = getObjectFromGUID(resources_GUID["materials"])
-
+    supply_tiles = {
+        psionic = resources_markers_GUID["psionics"],
+        relic = resources_markers_GUID["relics"],
+        weapon = resources_markers_GUID["weapons"],
+        fuel = resources_markers_GUID["fuel"],
+        material = resources_markers_GUID["materials"]
     },
     clusters = {{
         ["a"] = "weapon",
@@ -39,11 +38,39 @@ local Resource = {
 
 function Resource:take(name, pos)
     LOG.DEBUG("name:" .. name)
-    return self.supplies[name].takeObject({
-        position = pos,
-        rotation = {0, 180, 0},
-        smooth = true
-    })
+
+    -- perform a raycast to find the topmost resource on the supply tile
+    local supply_tile = getObjectFromGUID(self.supply_tiles[name:lower()])
+    local hits = Physics.cast(
+        {
+            origin = supply_tile.getPosition() + Vector(0, -1, 0),
+            direction = Vector(0,1,0),
+            type = 1
+        }
+    )
+
+    -- reverse iterate to get the top-most resource first
+    local result = nil
+    for i = #hits, 1, -1 do
+        if hits[i].hit_object.getName():lower() == name:lower() and not hits[i].hit_object.isSmoothMoving() then
+            result = hits[i].hit_object
+            break
+        end
+    end
+
+    if result.getQuantity() ~= -1 then
+        result = result.takeObject({
+            position = pos,
+            rotation = {0, 180, 0},
+            smooth = true
+        })
+    else
+        if pos ~= nil then
+            result.setPositionSmooth(pos, false, true)
+        end
+        result.setRotationSmooth({0, 180, 0}, false, true)
+    end
+    return result
 end
 
 function Resource:name_from_cluster(cluster, system)

--- a/src/Resource.lua
+++ b/src/Resource.lua
@@ -58,6 +58,11 @@ function Resource:take(name, pos)
         end
     end
 
+    -- early out if there's no resources in the supply
+    if result == nil then
+        return result
+    end
+
     if result.getQuantity() ~= -1 then
         result = result.takeObject({
             position = pos,


### PR DESCRIPTION
Resource:take expects there to always be a pile of resources in the supply and for that pile to always have the guid. This isn't the case because restacking the resources in a different order will change their guid. Instead of guid, we should use the location of the supply tiles to find the resources. This code uses a raycast since it can find the topmost resource in the pile even if they're not stacked
