### PR TITLE
[Bugfix] Adjusted how containers are handled

### DIFF
--- a/src/Global.lua
+++ b/src/Global.lua
@@ -222,24 +222,28 @@ end
 
 function onObjectLeaveContainer(container, leave_object)
     Counters.update(container)
-    if container.type == "Deck" or container.type == "Bag" or container.type ==
-        "Infinite" then
-        leave_object.setTags(container.getTags())
-
-        -- set snap
-        leave_object.use_snap_points = true
+    local container_tags = container.getTags()
+    if #container_tags > 0 then
+        if container.type == "Deck" or container.type == "Bag" or container.type ==
+            "Infinite" then
+            leave_object.setTags(container.getTags())
+    
+            -- set snap
+            leave_object.use_snap_points = true
+        end
     end
 end
 
 function tryObjectEnterContainer(container, object)
-    if object.getStateId() == 2 then
+    if object.hasTag('Ship') and container.hasTag('Ship') and object.getStateId() == 2 then
         object.setState(1)
     end
-
-    if container.hasTag("Ship") or container.hasTag("City") or
-        container.hasTag("Starport") or container.hasTag("Blight") or
-        container.hasTag("Agent") then
-        return container.hasMatchingTag(object)
+    
+    -- require object to have every container tag
+    for _,  tag in ipairs(container.getTags()) do
+        if not object.hasTag(tag) then
+            return false
+        end
     end
 
     return true


### PR DESCRIPTION
- made only ship containers change ships to their undamaged state.
- made it so containers without tags don't clear the tags on the objects being taken out of them
- the 'Lock' tag on containers was making it so objects could be put in any container. To solve this, require every container tag to be on the object before allowing it to be placed in the container
