### PR TITLE
add Guild tag to Lore deck + cards to allow for mixing during campaign

### DIFF
--- a/TS_Save.json
+++ b/TS_Save.json
@@ -73123,7 +73123,8 @@
         "b": 0.713235259
       },
       "Tags": [
-        "Lore"
+        "Lore",
+        "Guild"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -73199,7 +73200,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73260,7 +73262,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73321,7 +73324,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73382,7 +73386,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73443,7 +73448,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73504,7 +73510,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73565,7 +73572,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73626,7 +73634,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73687,7 +73696,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73748,7 +73758,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73809,7 +73820,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73870,7 +73882,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73931,7 +73944,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -73992,7 +74006,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74055,7 +74070,8 @@
         "b": 0.713235259
       },
       "Tags": [
-        "Lore"
+        "Lore",
+        "Guild"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -74131,7 +74147,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74192,7 +74209,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74253,7 +74271,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74314,7 +74333,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74375,7 +74395,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74436,7 +74457,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74497,7 +74519,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74558,7 +74581,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74619,7 +74643,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74680,7 +74705,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74741,7 +74767,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74802,7 +74829,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74863,7 +74891,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74924,7 +74953,8 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Lore"
+            "Lore",
+            "Guild"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,


### PR DESCRIPTION
To address issue raised with campaign setup failing to mix lore+court deck.