### PR TITLE
Comment out ambition button usage until it can be revisited

### DIFF
--- a/src/AmbitionMarkers.lua
+++ b/src/AmbitionMarkers.lua
@@ -139,7 +139,7 @@ function AmbitionMarkers.undo()
     if (last_declared_marker == nil) then
         Log.ERROR(
             "Could not find last declared ambition marker, resetting zero marker.")
-        AmbitionMarkers.display_declare_button()
+        -- AmbitionMarkers.display_declare_button()
         return
     end
     local undo_pos =
@@ -150,7 +150,7 @@ function AmbitionMarkers.undo()
     zero_marker.setPositionSmooth(reach_board.positionToWorld({0.94, 0.2, 1.09}))
     zero_marker.setRotationSmooth({0.00, 180.00, 0.00})
 
-    AmbitionMarkers.display_declare_button()
+    -- AmbitionMarkers.display_declare_button()
 end
 
 function AmbitionMarkers.reset_zero_marker()
@@ -187,7 +187,7 @@ end
 
 -- Begin Object Code --
 function onLoad()
-    AmbitionMarkers.add_button()
+    -- AmbitionMarkers.add_button()
 end
 function declare_ambition(obj, player_color)
 
@@ -247,7 +247,7 @@ function declare_ambition(obj, player_color)
     zero_marker.setPositionSmooth(reach_board.positionToWorld({1.02, 0.2, 0.67}))
     zero_marker.setRotationSmooth({0.00, 90.00, 0.00})
 
-    AmbitionMarkers.display_undo_button()
+    -- AmbitionMarkers.display_undo_button()
 end
 function undo_ambition(obj, player_color)
     AmbitionMarkers.undo(obj)


### PR DESCRIPTION
The declare ambition button and undo button is not consistent and sometimes prevents players from picking up the marker or removing it when they want.  Would recommend we comment out the functionality until it's working consistently to prevent frustration.  

I think we could achieve similar handling by using zones to detect the marker, rather than forcing a button on the object to move it around/declare it.  

There are also some secondary issues with the ambition handling, the ambition markers are clipping into the game board on some occasions, the sort order of the markers during an undo can stack them into each-other (clipping again). 