### PR TITLE
scale seized initiative down to prevent a seized teal from pushing power cubes

### DIFF
--- a/TS_Save.json
+++ b/TS_Save.json
@@ -73046,9 +73046,9 @@
             "rotX": -2.26203952E-06,
             "rotY": 0.000874913938,
             "rotZ": 4.203342E-06,
-            "scaleX": 1.0,
-            "scaleY": 1.0,
-            "scaleZ": 1.0
+            "scaleX": 0.6,
+            "scaleY": 0.6,
+            "scaleZ": 0.6
           },
           "Nickname": "Seized Initiative",
           "Description": "",


### PR DESCRIPTION
Ref #35  Otherwise, if the teal player seizes and there are cubes on 21/22/23, they can be pushed around.

I first tried adjusting the 2nd state position coordinates of the seized initiative object:
```
      "States": {
        "2": {
          "GUID": "e0f490",
          "Name": "Custom_Model",
          "Transform": {
            "posX": 25.7464676, <----
            "posY": 0.9566779,
            "posZ": 17.2232571, <----
            "rotX": -2.26203952E-06,
            "rotY": 0.000874913938,
            "rotZ": 4.203342E-06,
            "scaleX": 0.6,
            "scaleY": 0.6,
            "scaleZ": 0.6
          },
```

But this had no effect.  We could potentially update the initiative seize functions to capture the piece position, adjust one of the axis, and then setPosition() when the piece is seized, and reverse during an unseize.  But any 1/2 state changes on the piece would not work in isolation still...  So that maybe looks better rather than scaling down the piece...  but the scale-down is also simple/effective for this problem.