### PR TITLE
Add tags and names to campaign objects

### DIFF
--- a/TS_Save.json
+++ b/TS_Save.json
@@ -319,7 +319,15 @@
       {
         "displayed": "RedPiece",
         "normalized": "redpiece"
-      }
+      },
+      {
+        "displayed": "Edict",
+        "normalized": "edict"
+      },
+      {
+        "displayed": "Title",
+        "normalized": "title"
+      },
     ]
   },
   "Turns": {
@@ -60813,7 +60821,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.0
           },
-          "Nickname": "",
+          "Nickname": "GOVERN THE IMPERIAL REACH",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60826,6 +60834,10 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Edict"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -60871,7 +60883,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.0
           },
-          "Nickname": "",
+          "Nickname": "GOVERN THE IMPERIAL REACH",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60884,6 +60896,10 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Edict"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -60929,7 +60945,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.0
           },
-          "Nickname": "",
+          "Nickname": "GOVERN THE IMPERIAL REACH",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60942,6 +60958,10 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Edict"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -60989,7 +61009,7 @@
         "scaleY": 1.0,
         "scaleZ": 1.0
       },
-      "Nickname": "",
+      "Nickname": "GUILD ENVOYS DEPART",
       "Description": "",
       "GMNotes": "",
       "AltLookAngle": {
@@ -61003,7 +61023,8 @@
         "b": 0.713235259
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "Edict"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -61050,7 +61071,7 @@
         "scaleY": 1.0,
         "scaleZ": 1.0
       },
-      "Nickname": "",
+      "Nickname": "IMPERIAL COUNCIL",
       "Description": "",
       "GMNotes": "",
       "AltLookAngle": {
@@ -61065,7 +61086,8 @@
       },
       "Tags": [
         "Campaign Only",
-        "Council"
+        "Council",
+        "Court"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -61179,7 +61201,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.0
           },
-          "Nickname": "",
+          "Nickname": "IMPERIAL REGENT / OUTLAW",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -61193,7 +61215,10 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Regent"
+            "Campaign Only",
+            "Regent",
+            "Outlaw",
+            "Title"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -61240,7 +61265,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.0
           },
-          "Nickname": "",
+          "Nickname": "IMPERIAL REGENT / OUTLAW",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -61254,7 +61279,10 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Regent"
+            "Campaign Only",
+            "Regent",
+            "Outlaw",
+            "Title"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -61301,7 +61329,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.0
           },
-          "Nickname": "",
+          "Nickname": "IMPERIAL REGENT / OUTLAW",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -61316,7 +61344,9 @@
           },
           "Tags": [
             "Campaign Only",
-            "Regent"
+            "Regent",
+            "Outlaw",
+            "Title"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -61363,12 +61393,12 @@
             "scaleY": 1.0,
             "scaleZ": 1.0
           },
-          "Nickname": "",
+          "Nickname": "IMPERIAL REGENT / OUTLAW",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
-            "y": 0.0,
+            "y": 0.0,f
             "z": 0.0
           },
           "ColorDiffuse": {
@@ -61378,7 +61408,9 @@
           },
           "Tags": [
             "Campaign Only",
-            "Regent"
+            "Regent",
+            "Outlaw",
+            "Title"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -68472,7 +68504,8 @@
           },
           "Tags": [
             "Action",
-            "Campaign Only"
+            "Campaign Only",
+            "Event"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -55402,7 +55402,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F23"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -55441,8 +55442,8 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "Conspiracy",
-          "Description": "",
+          "Nickname": "CONSPIRACY TOKEN",
+          "Description": "Red",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -55455,7 +55456,8 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "F23"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -55467,7 +55469,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": false,
@@ -55521,8 +55523,8 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "Conspiracy",
-          "Description": "",
+          "Nickname": "CONSPIRACY TOKEN",
+          "Description": "White",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -55535,7 +55537,8 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "F23"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -55547,7 +55550,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": false,
@@ -55601,8 +55604,8 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "Conspiracy",
-          "Description": "",
+          "Nickname": "CONSPIRACY TOKEN",
+          "Description": "Yellow",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -55615,7 +55618,8 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "F23"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -55627,7 +55631,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": false,
@@ -55681,8 +55685,8 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "Conspiracy",
-          "Description": "",
+          "Nickname": "CONSPIRACY TOKEN",
+          "Description": "Yellow",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -55695,7 +55699,8 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "F23"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -55707,7 +55712,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": false,
@@ -55761,7 +55766,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "Conspiracy",
+          "Nickname": "CONSPIRACY TOKEN",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -55775,7 +55780,8 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "F23"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -55787,7 +55793,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": false,
@@ -55841,8 +55847,8 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "Conspiracy",
-          "Description": "",
+          "Nickname": "CONSPIRACY TOKEN",
+          "Description": "White",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -55855,7 +55861,8 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "F23"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -55867,7 +55874,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": false,
@@ -55921,8 +55928,8 @@
             "scaleY": 1.0,
             "scaleZ": 0.428595543
           },
-          "Nickname": "",
-          "Description": "",
+          "Nickname": "CONSPIRACY TOKEN",
+          "Description": "Teal",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -55934,6 +55941,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F23"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -55944,7 +55955,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": false,
@@ -55978,8 +55989,8 @@
             "scaleY": 1.0,
             "scaleZ": 0.428595543
           },
-          "Nickname": "",
-          "Description": "",
+          "Nickname": "CONSPIRACY TOKEN",
+          "Description": "Teal",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -55991,6 +56002,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F23"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -56001,7 +56016,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": false,
@@ -56102,7 +56117,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FOILING CONSPIRACIES",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -56116,7 +56131,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F23"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -56163,7 +56180,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SCORING CONSPIRACIES",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -56177,7 +56194,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F23"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -56224,7 +56243,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "CONSPIRACIES",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -56238,7 +56257,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Ability",
+                "F23"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -56285,7 +56306,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FARSEERS",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -56299,7 +56320,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F23"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -56360,7 +56384,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F23"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60347,7 +60374,8 @@
           "Tags": [
             "Campaign Only",
             "Leader",
-            "Fate"
+            "Fate",
+            
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -60410,7 +60438,8 @@
           "Tags": [
             "Campaign Only",
             "Leader",
-            "Fate"
+            "Fate",
+            "F22"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -54569,7 +54569,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F22"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -54608,7 +54609,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.306216359
           },
-          "Nickname": "",
+          "Nickname": "PASSAGE TOKEN",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -54621,6 +54622,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F22"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -54665,7 +54670,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.306216359
           },
-          "Nickname": "",
+          "Nickname": "PASSAGE TOKEN",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -54678,6 +54683,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F22"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -54722,7 +54731,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.306216359
           },
-          "Nickname": "",
+          "Nickname": "PASSAGE TOKEN",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -54735,6 +54744,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F22"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -54779,7 +54792,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.306216359
           },
-          "Nickname": "",
+          "Nickname": "PASSAGE TOKEN",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -54792,6 +54805,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F22"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -54836,7 +54853,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.306216359
           },
-          "Nickname": "",
+          "Nickname": "PASSAGE TOKEN",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -54849,6 +54866,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F22"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -54893,7 +54914,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.306216359
           },
-          "Nickname": "",
+          "Nickname": "PASSAGE TOKEN",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -54906,6 +54927,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F22"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -55018,7 +55043,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PASSAGE STORMS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -55032,7 +55057,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F22"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -55079,7 +55107,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PASSAGES & THE TWISTED PASSAGE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -55093,7 +55121,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F22"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -55140,7 +55170,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "THE DEAD LIVE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -55154,7 +55184,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Reminder",
+                "F22"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -55201,7 +55233,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BREAKING GATES & PLACING PASSAGES",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -55215,7 +55247,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Ability",
+                "F22"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -55262,7 +55296,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "CATAPULT OVERDRIVE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -55276,7 +55310,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F22"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -55337,7 +55374,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Objective",
+                "Setup",
+                "F22"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -44088,7 +44088,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F14"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -44127,8 +44128,8 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
-          "Description": "",
+          "Nickname": "WITNESS",
+          "Description": "Psionic",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -44141,7 +44142,9 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "Resource",
+            "F14"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -44187,8 +44190,8 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
-          "Description": "",
+          "Nickname": "WITNESS",
+          "Description": "Psionic",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -44201,7 +44204,9 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "Resource",
+            "F14"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -44247,8 +44252,8 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
-          "Description": "",
+          "Nickname": "WITNESS",
+          "Description": "Psionic",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -44261,7 +44266,9 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "Resource",
+            "F14"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -44307,8 +44314,8 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
-          "Description": "",
+          "Nickname": "WITNESS",
+          "Description": "Psionic",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -44321,7 +44328,9 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "Resource",
+            "F14"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -44441,7 +44450,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "REBUKE OF THE EMPATHS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -44455,7 +44464,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F14"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -44502,7 +44513,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "RECONCILE WITH THE OUTRAGED",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -44516,7 +44527,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Summit",
+                "F14"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -44563,7 +44576,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "EMPATHY FOR ALL",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -44577,7 +44590,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Reminder",
+                "F14"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -44624,7 +44639,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "EMPATHY FOR ALL",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -44638,7 +44653,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F14"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -44699,7 +44716,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F14"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -44746,7 +44766,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ITINERANT EMPATHS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -44760,7 +44780,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F14"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -44807,7 +44830,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ITINERANT EMPATHS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -44821,7 +44844,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F14"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -44868,7 +44894,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PSIONIC LIAISONS",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -44882,7 +44908,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F14"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -44943,7 +44972,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F14"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -44990,7 +45021,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "WELL OF EMPATHY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -45004,7 +45035,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F14"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -45051,7 +45085,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "WITNESSES",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -45065,7 +45099,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Ability",
+                "F14"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -45126,7 +45162,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F14"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60329,7 +60368,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "PACIFIST",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60342,6 +60381,10 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "F14"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -29591,6 +29591,10 @@
             "g": 0.8235294,
             "b": 0.796078444
           },
+          "Tags": [
+            "Campaign Only",
+            "WhitePiece"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -29646,6 +29650,10 @@
             "g": 0.58431375,
             "b": 0.6627451
           },
+          "Tags": [
+            "Campaign Only",
+            "TealPiece"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -29701,6 +29709,10 @@
             "g": 0.324964136,
             "b": 0.239212513
           },
+          "Tags": [
+            "Campaign Only",
+            "RedPiece"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -29756,6 +29768,10 @@
             "g": 0.716666639,
             "b": 0.0
           },
+          "Tags": [
+            "Campaign Only",
+            "YellowPiece"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -24533,7 +24533,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.0
           },
-          "Nickname": "SILVER_TONGUES",
+          "Nickname": "SILVER TONGUES",
           "Description": "Psionic",
           "GMNotes": "",
           "AltLookAngle": {

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -53049,7 +53049,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F19"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -53154,7 +53155,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "RELIC FENCE",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -53168,7 +53169,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F19"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -53215,7 +53219,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "REBUKE OF THE KEEPERS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -53229,7 +53233,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F19"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -53276,7 +53282,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IRE OF THE KEEPERS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -53290,7 +53296,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F19"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -53351,7 +53360,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F19"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60702,7 +60714,8 @@
           "Tags": [
             "Campaign Only",
             "Leader",
-            "Fate"
+            "Fate",
+            "F19"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -25702,7 +25702,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F8"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -25741,7 +25742,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "Wisdom",
+          "Nickname": "ZEAL",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -25754,6 +25755,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F8"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -25818,7 +25823,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "Wisdom",
+          "Nickname": "ZEAL",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -25831,6 +25836,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F8"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -25895,7 +25904,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "Wisdom",
+          "Nickname": "ZEAL",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -25908,6 +25917,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F8"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -25972,7 +25985,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "Wisdom",
+          "Nickname": "ZEAL",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -25985,6 +25998,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F8"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -26049,7 +26066,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "Wisdom",
+          "Nickname": "ZEAL",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -26062,6 +26079,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F8"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -26219,7 +26240,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BREAKING THE FAITH",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -26233,7 +26254,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -26280,7 +26303,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "DOMINANT FAITH",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -26294,7 +26317,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -26355,7 +26380,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -26402,7 +26430,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "REPRESSED FAITH",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -26416,7 +26444,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -26463,7 +26493,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SET LAY DOCTRINE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -26477,7 +26507,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -26524,7 +26556,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SECRET ORDER",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -26538,7 +26570,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -26585,7 +26620,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "THE PROPHET",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -26599,7 +26634,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -26660,7 +26698,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -26707,7 +26747,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "DOCTRINAL FAITH",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -26721,7 +26761,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -26782,7 +26824,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Doctrine",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -26829,7 +26873,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SET DOCTRINE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -26843,7 +26887,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -26904,7 +26950,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -26951,7 +27000,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SECRET ORDER",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -26965,7 +27014,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27012,7 +27064,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "THE PRODIGAL ONE",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -27026,7 +27078,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27073,7 +27128,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PLOT TO KIDNAP",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -27087,7 +27142,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27134,7 +27192,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "THE YOUNG LIGHT",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -27148,7 +27206,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27209,7 +27270,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27256,7 +27319,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PLURALISTIC FAITH",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -27270,7 +27333,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27317,7 +27382,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FAITHFUL CARDS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -27331,7 +27396,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27393,7 +27460,8 @@
               },
               "Tags": [
                 "Campaign Only",
-                "Action"
+                "Action",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27455,7 +27523,8 @@
               },
               "Tags": [
                 "Campaign Only",
-                "Action"
+                "Action",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27517,7 +27586,8 @@
               },
               "Tags": [
                 "Campaign Only",
-                "Action"
+                "Action",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27579,7 +27649,8 @@
               },
               "Tags": [
                 "Campaign Only",
-                "Action"
+                "Action",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27641,7 +27712,8 @@
               },
               "Tags": [
                 "Campaign Only",
-                "Action"
+                "Action",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27703,7 +27775,8 @@
               },
               "Tags": [
                 "Campaign Only",
-                "Action"
+                "Action",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27765,7 +27838,8 @@
               },
               "Tags": [
                 "Campaign Only",
-                "Action"
+                "Action",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27827,7 +27901,8 @@
               },
               "Tags": [
                 "Campaign Only",
-                "Action"
+                "Action",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27889,7 +27964,8 @@
               },
               "Tags": [
                 "Campaign Only",
-                "Action"
+                "Action",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27936,7 +28012,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SPREADING THE FAITH",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -27950,7 +28026,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Ability",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -27997,7 +28075,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FAITHFUL DISCIPLES",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -28011,7 +28089,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -28072,7 +28153,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F8"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60255,7 +60339,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "BELIEVER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60268,6 +60352,12 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate",
+            "F8"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -50126,7 +50126,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F16"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -50165,7 +50166,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.4405907
           },
-          "Nickname": "",
+          "Nickname": "COURT",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -50178,6 +50179,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -50222,7 +50227,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.4405907
           },
-          "Nickname": "",
+          "Nickname": "COURT",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -50235,6 +50240,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -50279,7 +50288,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.4405907
           },
-          "Nickname": "",
+          "Nickname": "COURT",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -50292,6 +50301,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -50336,7 +50349,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.4405907
           },
-          "Nickname": "",
+          "Nickname": "COURT",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -50349,6 +50362,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -50393,7 +50410,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.4405907
           },
-          "Nickname": "",
+          "Nickname": "COURT",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -50406,6 +50423,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -50450,7 +50471,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.4405907
           },
-          "Nickname": "",
+          "Nickname": "COURT",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -50463,6 +50484,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -50507,7 +50532,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "SEAT",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -50520,6 +50545,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -50564,7 +50593,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "SEAT",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -50577,6 +50606,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -50621,7 +50654,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "SEAT",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -50634,6 +50667,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -50678,7 +50715,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "SEAT",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -50691,6 +50728,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -50735,7 +50776,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "SEAT",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -50748,6 +50789,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -50792,7 +50837,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "SEAT",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -50805,6 +50850,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -50930,7 +50979,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LORDS GAIN POWER",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -50944,7 +50993,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -50991,7 +51042,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FEUDAL COURTS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51005,7 +51056,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51066,7 +51119,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51113,7 +51169,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SWORN GUARDIANS",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51127,7 +51183,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51174,7 +51233,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SKIRMISHERS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51188,7 +51247,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51235,7 +51297,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FEAST DAY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51249,7 +51311,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51296,7 +51361,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FEAST DAY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51310,7 +51375,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51357,7 +51425,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "WARDEN'S LEVY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51371,7 +51439,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51432,7 +51503,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution"
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51479,7 +51552,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FEUDAL LAW",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51493,7 +51566,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51540,7 +51615,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SEATS AND FIEFS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51554,7 +51629,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51601,7 +51678,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LORD OF THE 6TH CLUSTER",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51615,7 +51692,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Title",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51662,7 +51741,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LORD OF THE 5TH CLUSTER",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51676,7 +51755,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Title",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51723,7 +51804,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LORD OF THE 4TH CLUSTER",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51737,7 +51818,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Title",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51784,7 +51867,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LORD OF THE 3RD CLUSTER",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51798,7 +51881,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Title",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51845,7 +51930,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LORD OF THE 2ND CLUSTER",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51859,7 +51944,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Title",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51906,7 +51993,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LORD OF THE 1ST CLUSTER",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51920,7 +52007,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Title",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -51967,7 +52056,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "CLAIMS OF NOBILITY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -51981,7 +52070,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -52042,7 +52134,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F16"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60303,7 +60398,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "WARDEN",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60316,6 +60411,12 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate"
+            "F16"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -51735,7 +51735,7 @@
               },
               "Tags": [
                 "Campaign Only",
-                "Resolution"
+                "Resolution",
                 "F16"
               ],
               "LayoutGroupSortIndex": 0,
@@ -60671,7 +60671,7 @@
           "Tags": [
             "Campaign Only",
             "Leader",
-            "Fate"
+            "Fate",
             "F16"
           ],
           "LayoutGroupSortIndex": 0,
@@ -60874,7 +60874,7 @@
             "Campaign Only",
             "Leader",
             "Fate",
-            
+            "F23"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -37030,7 +37030,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F4"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -37157,7 +37158,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GUILD SUPREMACY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -37171,7 +37172,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Reminder",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37218,7 +37221,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GUILD SUPREMACY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -37232,7 +37235,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37279,7 +37284,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GUILD LOYALTY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -37293,7 +37298,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37354,7 +37362,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37401,7 +37412,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GUILDS WITHDRAW",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -37415,7 +37426,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37462,7 +37476,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PSIONIC GUILDMASTERS",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -37476,7 +37490,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37523,7 +37540,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "RELIC GUILDMASTERS",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -37537,7 +37554,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37584,7 +37604,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "WEAPONS GUILDMASTERS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -37598,7 +37618,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37645,7 +37668,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FUEL GUILDMASTERS",
               "Description": "Fuel",
               "GMNotes": "",
               "AltLookAngle": {
@@ -37659,7 +37682,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37706,7 +37732,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MATERIAL GUILDMASTERS",
               "Description": "Material",
               "GMNotes": "",
               "AltLookAngle": {
@@ -37720,7 +37746,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37767,7 +37796,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GUILD FAIR",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -37781,7 +37810,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37842,7 +37874,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37889,7 +37923,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GUILD NEGOTIATIONS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -37903,7 +37937,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Summit",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -37950,7 +37986,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ADVOCATE'S DEMAND",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -37964,7 +38000,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38025,7 +38063,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38072,7 +38113,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GUILD STRUGGLE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38086,7 +38127,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38133,7 +38177,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "DIPLOMATIC FIASCO",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38147,7 +38191,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38194,7 +38241,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PSIONIC LIAISONS",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38208,7 +38255,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38255,7 +38305,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "RELIC LIAISONS",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38269,7 +38319,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38316,7 +38369,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "WEAPONS LIAISONS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38330,7 +38383,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38377,7 +38433,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FUEL LIAISONS",
               "Description": "Fuel",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38391,7 +38447,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38438,7 +38497,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MATERIAL LIAISONS",
               "Description": "Material",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38452,7 +38511,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38513,7 +38575,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38560,7 +38624,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GUILD OVERSEERS",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38574,7 +38638,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38621,7 +38688,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GUILD INVESTIGATORS",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38635,7 +38702,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38696,7 +38766,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F4"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60121,7 +60194,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "ADVOCATE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60136,7 +60209,9 @@
           },
           "Tags": [
             "Campaign Only",
-            "Leader"
+            "Leader",
+            "Fate",
+            "F4"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -52107,7 +52107,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F18"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -52146,7 +52147,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BUNKER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -52159,6 +52160,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F18"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -52203,7 +52208,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BUNKER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -52216,6 +52221,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F18"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -52260,7 +52269,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BUNKER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -52273,6 +52282,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F18"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -52317,7 +52330,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BUNKER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -52330,6 +52343,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F18"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -52374,7 +52391,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BUNKER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -52387,6 +52404,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F18"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -52431,7 +52452,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BUNKER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -52444,6 +52465,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F18"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -52488,7 +52513,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BUNKER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -52501,6 +52526,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F18"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -52545,7 +52574,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BUNKER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -52558,6 +52587,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F18"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -52602,7 +52635,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BUNKER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -52615,6 +52648,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F18"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -52726,7 +52763,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "CAPTIVE RELEASE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -52740,7 +52777,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F18"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -52787,7 +52826,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BUNKERS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -52801,7 +52840,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F18"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -52848,7 +52889,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BUILDING BUNKERS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -52862,7 +52903,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Ability",
+                "F18"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -52909,7 +52952,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "VOW OF SURVIVAL",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -52923,7 +52966,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F18"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -52984,7 +53030,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60778,7 +60826,8 @@
           "Tags": [
             "Campaign Only",
             "Leader",
-            "Fate"
+            "Fate",
+            "F18"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -53840,7 +53840,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F21"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -53879,7 +53880,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.1029588
           },
-          "Nickname": "",
+          "Nickname": "BLIGHTKIN",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -53892,6 +53893,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F21"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -54002,7 +54007,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BLIGHTKIN AMBITION",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -54016,7 +54021,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F21"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -54063,7 +54070,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SPORE GUIDES",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -54077,7 +54084,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F21"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -54124,7 +54134,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BLIGHT SOCIETY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -54138,7 +54148,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F21"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -54199,7 +54212,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Objective",
+                "Setup",
+                "F21"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60542,7 +60558,8 @@
           "Tags": [
             "Campaign Only",
             "Leader",
-            "Fate"
+            "Fate",
+            "F21"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -54356,7 +54356,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F17"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -54460,7 +54461,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "REACH REJECTS OVERLORD",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -54474,7 +54475,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F17"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -54521,7 +54524,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SYCOPHANTS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -54535,7 +54538,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F17"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -54596,7 +54602,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F17"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60890,7 +60899,8 @@
           "Tags": [
             "Campaign Only",
             "Leader",
-            "Fate"
+            "Fate",
+            "F17"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -31844,8 +31844,8 @@
           },
           "Tags": [
             "Campaign Only",
-            "F4""F4""F4""F4""F3"
-          ],,,,,
+            "F3"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -41792,7 +41792,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F12"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -41831,7 +41832,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "RUMOR",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -41844,6 +41845,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F12"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -41888,7 +41893,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "RUMOR",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -41901,6 +41906,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F12"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -41945,7 +41954,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "RUMOR",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -41958,6 +41967,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F12"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -42002,7 +42015,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "RUMOR",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -42015,6 +42028,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F12"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -42133,7 +42150,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SHARING RUMORS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -42147,7 +42164,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Summit",
+                "F12"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42194,7 +42213,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "RUMORS OF THE HAVEN",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -42208,7 +42227,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F12"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42255,7 +42276,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "RUMORS SPREAD",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -42269,7 +42290,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F12"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42316,7 +42340,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "RUMORS SPREAD",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -42330,7 +42354,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F12"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42391,7 +42418,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F12"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42438,7 +42468,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SILVER-TONGUES",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -42452,7 +42482,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F12"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42499,7 +42532,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "CALL TO ACTION",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -42513,7 +42546,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F12"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42560,7 +42596,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PIRATE SMUGGLERS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -42574,7 +42610,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F12"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42635,7 +42674,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F12"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42682,7 +42723,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PIRATE FLEET",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -42696,7 +42737,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F12"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42743,7 +42787,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PIRATE HOARD",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -42757,7 +42801,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F12"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42818,7 +42865,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F12"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60288,7 +60338,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "PIRATE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60301,6 +60351,10 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "F12"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -53416,7 +53416,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F20"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -53455,7 +53456,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.1029588
           },
-          "Nickname": "",
+          "Nickname": "EDENGUARD",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -53468,6 +53469,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F20"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -53578,7 +53583,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "EDENGUARD AMBITION",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -53592,7 +53597,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F20"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -53639,7 +53646,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IRE OF THE TYCOONS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -53653,7 +53660,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F20"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -53700,7 +53710,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GREEN VAULT",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -53714,7 +53724,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F20"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -53775,7 +53788,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F20"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60622,7 +60638,8 @@
           "Tags": [
             "Campaign Only",
             "Leader",
-            "Fate"
+            "Fate",
+            "F20"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -60196,7 +60196,8 @@
       },
       "Tags": [
         "Campaign Only",
-        "Leader"
+        "Leader",
+        "Fate"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -60252,7 +60253,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "JUDGE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60265,6 +60266,11 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -60310,7 +60316,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "CONSPIRATOR",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60323,6 +60329,11 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -60368,7 +60379,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "GATE WRAITH",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60381,6 +60392,11 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -60426,7 +60442,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "NATURALIST",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60439,6 +60455,11 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -60484,7 +60505,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "GUARDIAN",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60497,6 +60518,11 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -60542,7 +60568,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "REDEEMER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60555,6 +60581,11 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -60600,7 +60631,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "SURVIVALIST",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60613,6 +60644,11 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -60658,7 +60694,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "OVERLORD",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60671,6 +60707,11 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -45230,7 +45230,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F13"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -45344,7 +45345,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BLIGHT HUNGER",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -45358,7 +45359,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F13"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -45419,7 +45423,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F13"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -45466,7 +45473,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BLIGHT LOOMS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -45480,7 +45487,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F13"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -45527,7 +45537,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BLIGHT PANIC",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -45541,7 +45551,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F13"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -45588,7 +45601,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BLIGHT PURGE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -45602,7 +45615,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F13"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -45649,7 +45665,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BLIGHT PURGE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -45663,7 +45679,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F13"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -45710,7 +45729,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BLIGHT PURGE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -45724,7 +45743,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F13"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -45771,7 +45793,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BLIGHT REAPERS",
               "Description": "Material",
               "GMNotes": "",
               "AltLookAngle": {
@@ -45785,7 +45807,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F13"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -45832,7 +45857,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BLIGHT HUNTERS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -45846,7 +45871,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F13"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -45893,7 +45921,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BLIGHT FURY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -45907,7 +45935,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F13"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -45968,7 +45999,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F13"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -46015,7 +46048,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SPORE SHIPS",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -46029,7 +46062,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F13"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60310,7 +60346,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "BLIGHT SPEAKER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60323,6 +60359,12 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate",
+            "F13"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -46300,7 +46300,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F10"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -46339,7 +46340,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BANNER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -46352,6 +46353,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F10"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -46396,7 +46401,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BANNER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -46409,6 +46414,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F10"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -46453,7 +46462,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BANNER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -46466,6 +46475,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F10"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -46510,7 +46523,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BANNER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -46523,6 +46536,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F10"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -46567,7 +46584,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BANNER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -46580,6 +46597,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F10"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -46624,7 +46645,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BANNER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -46637,6 +46658,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F10"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -46681,7 +46706,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BANNER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -46694,6 +46719,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F10"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -46738,7 +46767,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "BANNER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -46751,6 +46780,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F10"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -46869,7 +46902,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "HAPPY HOSTS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -46883,7 +46916,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F10"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -46944,7 +46980,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F10"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -46991,7 +47030,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "AGAINST HEGEMONY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -47005,7 +47044,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F10"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -47052,7 +47094,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "AGAINST HEGEMONY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -47066,7 +47108,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F10"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -47113,7 +47158,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PRISON WARDENS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -47127,7 +47172,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F10"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -47174,7 +47222,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PRISON WARDENS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -47188,7 +47236,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F10"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -47235,7 +47286,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MIND MANAGERS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -47249,7 +47300,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F10"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -47310,7 +47364,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F10"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -47357,7 +47413,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SONG OF THE BANNER",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -47371,7 +47427,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F10"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -47418,7 +47477,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BANNERS OF HEGEMONY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -47432,7 +47491,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F10"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -47479,7 +47540,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PLANTING BANNERS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -47493,7 +47554,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Ability",
+                "F10"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -47554,7 +47617,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F10"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60281,7 +60347,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "HEGEMON",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60294,6 +60360,12 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate",
+            "F10"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -47701,7 +47701,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F9"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -47740,7 +47741,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "PILGRIM",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -47753,6 +47754,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -47797,7 +47802,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "PILGRIM",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -47810,6 +47815,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -47854,7 +47863,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "PILGRIM",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -47867,6 +47876,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -47911,7 +47924,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "PILGRIM",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -47924,6 +47937,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -47968,7 +47985,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "PILGRIM",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -47981,6 +47998,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -48025,7 +48046,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "PILGRIM",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -48038,6 +48059,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -48082,7 +48107,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "PORTAL",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -48095,6 +48120,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -48139,7 +48168,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "CLUE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -48152,6 +48181,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -48196,7 +48229,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "CLUE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -48209,6 +48242,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -48253,7 +48290,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "CLUE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -48266,6 +48303,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -48310,7 +48351,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "CLUE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -48323,6 +48364,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -48367,7 +48412,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "CLUE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -48380,6 +48425,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -48424,7 +48473,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "CLUE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -48437,6 +48486,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -48554,7 +48607,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SEEK THE PORTAL",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -48568,7 +48621,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F9"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -48615,7 +48671,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SEEK THE PORTAL",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -48629,7 +48685,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F9"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -48676,7 +48735,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SEEK THE PORTAL",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -48690,7 +48749,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F9"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -48737,7 +48799,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PILGRIMS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -48751,7 +48813,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Ability",
+                "F9"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -48812,7 +48876,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F9"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -48859,7 +48926,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PORTAL SEEKERS",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -48873,7 +48940,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F9"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -48920,7 +48990,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "CALL TO PILGRIMAGE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -48934,7 +49004,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F9"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -48995,7 +49068,8 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -49042,7 +49116,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "CLUES TO THE PORTAL",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -49056,7 +49130,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Ability",
+                "F9"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -49103,7 +49179,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "UNCOVERING CLUES",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -49117,7 +49193,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Ability",
+                "F9"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -49178,7 +49256,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F9"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60305,7 +60386,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "PATHFINDER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60318,6 +60399,10 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "F9"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -31718,7 +31718,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F3"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -31757,7 +31758,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "War Profiteer",
+          "Nickname": "WAR PROFITEER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -31770,6 +31771,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F4""F4""F4""F4""F3"
+          ],,,,,
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -31903,7 +31908,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "CLOSED & OPEN ECONOMY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -31917,7 +31922,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -31964,7 +31971,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ECONOMY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -31978,7 +31985,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Economy",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32039,7 +32048,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32086,7 +32098,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "EXTORTION",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32100,7 +32112,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32147,7 +32162,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "EXTORTION",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32161,7 +32176,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32208,7 +32226,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PROSPECTORS",
               "Description": "Material",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32222,7 +32240,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32283,7 +32304,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32330,7 +32353,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "WAR PROFITEERING",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32344,7 +32367,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32391,7 +32416,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MONOPOLY CONSENT",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32405,7 +32430,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Summit",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32452,7 +32479,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GAIN MONOPOLIES",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32466,7 +32493,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32513,7 +32542,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "WEAPON MONOPOLY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32527,7 +32556,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Monopoly",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32574,7 +32605,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PSIONIC MONOPOLY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32588,7 +32619,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Monopoly",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32635,7 +32668,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "RELIC MONOPOLY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32649,7 +32682,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Monopoly",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32696,7 +32731,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FUEL MONOPOLY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32710,7 +32745,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Monopoly",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32757,7 +32794,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MATERIAL MONOPOLY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32771,7 +32808,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Monopoly",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32832,7 +32871,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32879,7 +32921,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "RELIC CARTEL",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32893,7 +32935,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -32940,7 +32985,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PSIONIC CARTEL",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -32954,7 +32999,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -33001,8 +33049,8 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
-              "Description": "",
+              "Nickname": "WEAPON CARTEL",
+              "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
                 "x": 0.0,
@@ -33015,7 +33063,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -33062,7 +33113,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FUEL CARTEL",
               "Description": "Fuel",
               "GMNotes": "",
               "AltLookAngle": {
@@ -33076,7 +33127,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -33123,7 +33177,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MATERIAL CARTEL",
               "Description": "Material",
               "GMNotes": "",
               "AltLookAngle": {
@@ -33137,7 +33191,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -33184,7 +33241,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PRISON WARDENS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -33198,7 +33255,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -33245,7 +33305,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "RELIC FENCE",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -33259,7 +33319,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -33306,7 +33369,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ELDER BROKER",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -33320,7 +33383,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -33381,7 +33447,8 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -33428,7 +33495,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MERCHANT LEAGUE",
               "Description": "Fuel",
               "GMNotes": "",
               "AltLookAngle": {
@@ -33442,7 +33509,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -33503,7 +33573,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F3"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60381,7 +60454,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "MAGNATE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60395,7 +60468,10 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Leader"
+            "Campaign Only",
+            "Leader",
+            "Fate",
+            "F3"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -29930,7 +29930,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F1"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -30114,7 +30115,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GOVERN WITH AUTHORITY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -30128,7 +30129,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30175,7 +30178,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GOVERN WITH AUTHORITY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -30189,7 +30192,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30236,7 +30241,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GOVERN WITH AUTHORITY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -30250,7 +30255,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30297,7 +30304,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IMPERIAL SPONSOR",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -30311,7 +30318,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30372,7 +30381,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30419,7 +30431,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LESSER REGENT",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -30433,7 +30445,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30480,7 +30495,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LESSER REGENT",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -30494,7 +30509,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30541,7 +30559,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IMPERIAL DEFECTORS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -30555,7 +30573,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30602,7 +30623,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IMPERIAL DEFECTORS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -30616,7 +30637,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30663,7 +30687,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GALACTIC BARDS",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -30677,7 +30701,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30724,7 +30751,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "COUNCIL INSIDERS",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -30738,7 +30765,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30785,7 +30815,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "NAVY REPRISAL",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -30799,7 +30829,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30860,7 +30893,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30907,7 +30942,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IMPERIAL QUORUM",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -30921,7 +30956,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -30982,7 +31019,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -31029,7 +31069,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LESSER REGENT",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -31043,7 +31083,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -31090,7 +31133,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LESSER REGENT",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -31104,7 +31147,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -31151,7 +31197,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IMPERIAL PROTECTORS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -31165,7 +31211,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -31212,7 +31260,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "EMPIRE FALLS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -31226,7 +31274,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -31273,7 +31324,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "HUNTER SQUADS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -31287,7 +31338,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -31334,7 +31388,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "TAX COLLECTORS",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -31348,7 +31402,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -31409,7 +31466,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -31456,7 +31515,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "COUNCIL INTRIGUE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -31470,7 +31529,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -31517,7 +31579,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "DEALMAKERS",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -31531,7 +31593,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -31578,7 +31643,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IMPERIAL AUTHORITY",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -31592,7 +31657,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -31653,7 +31721,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F1"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60467,7 +60538,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "STEWARD",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60481,7 +60552,10 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Leader"
+            "Campaign Only",
+            "Leader",
+            "Fate",
+            "F1"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -38618,7 +38618,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F7"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -38740,7 +38741,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MARTIAL LAW",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38754,7 +38755,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Reminder",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38801,7 +38804,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MARTIAL LAW",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38815,7 +38818,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38876,7 +38881,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38923,7 +38931,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MASS UPRISING",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38937,7 +38945,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -38984,7 +38995,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MASS UPRISING",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -38998,7 +39009,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39045,7 +39059,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IMPERIAL DEFECTORS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -39059,7 +39073,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39106,7 +39123,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IMPERIAL DEFECTORS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -39120,7 +39137,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39181,7 +39201,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39228,7 +39250,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "COMMAND CHAOS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -39242,7 +39264,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39303,7 +39328,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Objective",
+                "Setup",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39350,7 +39378,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IMPERIAL DEFECTORS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -39364,7 +39392,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39411,7 +39442,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IMPERIAL DEFECTORS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -39425,7 +39456,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39472,7 +39506,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "COURT ENFORCERS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -39486,7 +39520,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39533,7 +39570,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "COURT ENFORCERS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -39547,7 +39584,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39594,7 +39634,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ROGUE ADMIRALS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -39608,7 +39648,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39655,7 +39698,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ROGUE ADMIRALS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -39669,7 +39712,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39716,7 +39762,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "HONOR GUARD",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -39730,7 +39776,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39791,7 +39840,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39838,7 +39889,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "USE IMPERIAL FOUNDRIES",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -39852,7 +39903,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39899,7 +39952,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "IMPERIAL OFFICERS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -39913,7 +39966,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -39974,7 +40030,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F7"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60281,7 +60340,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "ADMIRAL",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60294,6 +60353,12 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate",
+            "F7"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -48977,7 +48977,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F15"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -49016,7 +49017,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "CEASEFIRE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -49029,6 +49030,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F15"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -49073,7 +49078,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "CEASEFIRE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -49086,6 +49091,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F15"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -49130,7 +49139,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "CEASEFIRE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -49143,6 +49152,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F15"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -49187,7 +49200,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "CEASEFIRE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -49200,6 +49213,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F15"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -49244,7 +49261,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "CEASEFIRE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -49258,7 +49275,8 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "F15"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -49304,7 +49322,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "CEASEFIRE",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -49318,7 +49336,8 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "F15"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -49437,7 +49456,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PEACE ACCORDS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -49451,7 +49470,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Summit",
+                "F15"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -49498,7 +49519,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PEACE DIVIDENDS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -49512,7 +49533,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F15"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -49559,7 +49582,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "EMPIRE BALKS AT PEACE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -49573,7 +49596,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F15"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -49620,7 +49645,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "CEASEFIRES",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -49634,7 +49659,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F15"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -49695,7 +49722,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F15"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -49742,7 +49772,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ARMS INTEREST",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -49756,7 +49786,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F15"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -49803,7 +49836,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ARMS INTEREST",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -49817,7 +49850,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F15"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -49878,7 +49914,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F15"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -49925,7 +49963,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ARSENAL KEEPERS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -49939,7 +49977,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F15"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -49986,7 +50027,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "OATH OF PEACE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -50000,7 +50041,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F15"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -50061,7 +50105,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Subject",
+                "Objective",
+                "F15"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60340,7 +60387,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "PEACEKEEPER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60353,6 +60400,12 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate",
+            "F15"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -40387,7 +40387,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F2"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -40426,7 +40427,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.238342762
           },
-          "Nickname": "Commonwealth Ambition",
+          "Nickname": "COMMONWEALTH AMBITION",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -40440,7 +40441,8 @@
             "b": 1.0
           },
           "Tags": [
-            "Campaign Only"
+            "Campaign Only",
+            "F2"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -40575,7 +40577,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FREEDOM FIGHTERS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -40589,7 +40591,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -40636,7 +40641,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MASS CALL FOR ARMISTICE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -40650,7 +40655,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -40711,7 +40718,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -40758,7 +40768,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SPIRIT OF FREEDOM",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -40772,7 +40782,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -40833,7 +40846,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -40880,7 +40895,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "COMMONWEALTH MEMBERSHIP",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -40894,7 +40909,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -40941,7 +40958,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MEMBER OF THE COMMONWEALTH",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -40955,7 +40972,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Title",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41002,7 +41021,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MEMBER OF THE COMMONWEALTH",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41016,7 +41035,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Title",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41063,7 +41084,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MEMBER OF THE COMMONWEALTH",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41077,7 +41098,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Title",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41124,7 +41147,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "MEMBER OF THE COMMONWEALTH",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41138,7 +41161,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Title",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41185,7 +41210,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ARMISTICE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41199,7 +41224,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41246,7 +41274,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ARMISTICE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41260,7 +41288,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41307,7 +41338,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "CALL FOR ARMISTICE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41321,7 +41352,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41368,7 +41401,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "COMMONWEALTH AMBITION",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41382,7 +41415,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41429,7 +41464,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FOUNDER OF THE COMMONWEALTH",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41443,7 +41478,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Title",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41504,7 +41541,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41551,7 +41591,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ADMIN UNION",
               "Description": "Material",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41565,7 +41605,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41612,7 +41655,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ADMIN UNION",
               "Description": "Material",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41626,7 +41669,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41673,7 +41719,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "CONSTRUCTION UNION",
               "Description": "Material",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41687,7 +41733,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41734,7 +41783,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "CONSTRUCTION UNION",
               "Description": "Material",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41748,7 +41797,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41795,7 +41847,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "POLITICAL INTRIGUE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41809,7 +41861,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41856,7 +41911,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "POLITICAL INTRIGUE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41870,7 +41925,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41917,7 +41975,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "POLITICAL INTRIGUE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41931,7 +41989,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -41978,7 +42039,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BOOK OF LIBERATION",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -41992,7 +42053,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42053,7 +42117,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42100,7 +42166,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PARADE FLEETS",
               "Description": "Fuel",
               "GMNotes": "",
               "AltLookAngle": {
@@ -42114,7 +42180,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -42175,7 +42244,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Objective",
+                "Setup",
+                "F2"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60331,7 +60403,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "FOUNDER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60346,7 +60418,9 @@
           },
           "Tags": [
             "Campaign Only",
-            "Leader"
+            "Leader",
+            "Fate",
+            "F2"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -56425,7 +56425,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F24"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -56531,7 +56532,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "JUDGE SETS AGENDA",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -56545,7 +56546,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F24"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -56592,7 +56595,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "JUDGE'S CHOSEN",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -56606,7 +56609,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Title",
+                "F24"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -56653,7 +56658,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "THE ARBITER",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -56667,7 +56672,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F24"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -56714,7 +56722,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "VOW OF FAIRNESS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -56728,7 +56736,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F24"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -56789,7 +56800,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Objective",
+                "Setup",
+                "F24"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60269,7 +60283,8 @@
           "Tags": [
             "Campaign Only",
             "Leader",
-            "Fate"
+            "Fate",
+            "F24"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -33568,7 +33568,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F5"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -33607,7 +33608,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "GOLEM",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -33620,6 +33621,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F5"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -33664,7 +33669,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "GOLEM",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -33677,6 +33682,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F5"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -33721,7 +33730,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "GOLEM",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -33734,6 +33743,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F5"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -33778,7 +33791,7 @@
             "scaleY": 1.0,
             "scaleZ": 0.432334363
           },
-          "Nickname": "",
+          "Nickname": "GOLEM",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -33791,6 +33804,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F5"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -33918,7 +33935,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GOLEMS SATE THEIR APPETITE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -33932,7 +33949,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -33993,7 +34012,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34040,7 +34062,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GOLEM WORSHIP",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -34054,7 +34076,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34101,7 +34126,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GOLEM WORSHIP",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -34115,7 +34140,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34162,7 +34190,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GOLEM WORSHIP",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -34176,7 +34204,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34237,7 +34268,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34299,7 +34332,8 @@
               },
               "Tags": [
                 "Campaign Only",
-                "Action"
+                "Action",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34346,7 +34380,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "KNOWLEDGE SET FREE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -34360,7 +34394,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Summit",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34407,7 +34443,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LIBRARIANS",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -34421,7 +34457,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34482,7 +34521,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34529,7 +34571,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "UNSTABLE WARRIOR",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -34543,7 +34585,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34590,7 +34635,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "UNSTABLE PROTECTOR",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -34604,7 +34649,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34651,7 +34699,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "UNSTABLE SEEKER",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -34665,7 +34713,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34712,7 +34763,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "UNSTABLE HARVESTER",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -34726,7 +34777,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34787,7 +34841,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34834,7 +34890,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GOLEM ACTIONS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -34848,7 +34904,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34895,7 +34953,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GOLEMS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -34909,7 +34967,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -34956,7 +35016,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "STONE-SPEAKERS",
               "Description": "Material",
               "GMNotes": "",
               "AltLookAngle": {
@@ -34970,7 +35030,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35017,7 +35080,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GOLEM HEARTH",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -35031,7 +35094,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35078,7 +35144,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GOLEM BEACON",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -35092,7 +35158,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35153,7 +35222,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F5"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60295,7 +60367,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "CARETAKER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60308,6 +60380,10 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "F5"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -35218,7 +35218,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F6"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -35344,7 +35345,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SOWER OF DIVISION",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -35358,7 +35359,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35419,7 +35423,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35466,7 +35473,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ARMS UNION",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -35480,7 +35487,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35527,7 +35537,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SPACING UNION",
               "Description": "Fuel",
               "GMNotes": "",
               "AltLookAngle": {
@@ -35541,7 +35551,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35588,7 +35601,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "TERROR STRIKE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -35602,7 +35615,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35649,7 +35665,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "TERROR STRIKE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -35663,7 +35679,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35710,7 +35729,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GUILDS DECRY TERROR",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -35724,7 +35743,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Edict",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35785,7 +35806,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35832,7 +35855,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PEOPLE'S HERO",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -35846,7 +35869,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35893,7 +35919,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PARTISAN SEIZING",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -35907,7 +35933,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Law",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -35968,7 +35996,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36015,7 +36046,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "OUTRAGE SPREADS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -36029,7 +36060,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36076,7 +36110,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "OUTRAGE SPREADS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -36090,7 +36124,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36137,7 +36174,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "ARMS UNION",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -36151,7 +36188,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36198,7 +36238,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SPACING UNION",
               "Description": "Fuel",
               "GMNotes": "",
               "AltLookAngle": {
@@ -36212,7 +36252,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36259,7 +36302,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "GALACTIC BARDS",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -36273,7 +36316,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36320,7 +36366,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LOYAL KEEPERS",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -36334,7 +36380,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36381,7 +36430,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LOYAL EMPATHS",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -36395,7 +36444,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36442,7 +36494,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LOYAL MARINES",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -36456,7 +36508,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36503,7 +36558,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LOYAL PILOTS",
               "Description": "Fuel",
               "GMNotes": "",
               "AltLookAngle": {
@@ -36517,7 +36572,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36564,7 +36622,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LOYAL ENGINEERS",
               "Description": "Material",
               "GMNotes": "",
               "AltLookAngle": {
@@ -36578,7 +36636,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36639,7 +36700,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36686,7 +36749,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PARTISAN SEIZING",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -36700,7 +36763,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Ability",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36747,7 +36812,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "INFORMANTS",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -36761,7 +36826,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -36822,7 +36890,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F6"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60282,7 +60353,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "PARTISAN",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60295,6 +60366,12 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate",
+            "F6"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -42933,7 +42933,8 @@
         "b": 0.0
       },
       "Tags": [
-        "Campaign Only"
+        "Campaign Only",
+        "F11"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -42985,6 +42986,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F11"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -43042,6 +43047,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F11"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -43099,6 +43108,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F11"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -43156,6 +43169,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F11"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -43213,6 +43230,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F11"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -43270,6 +43291,10 @@
             "g": 1.0,
             "b": 1.0
           },
+          "Tags": [
+            "Campaign Only",
+            "F11"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -43402,7 +43427,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F11"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -43449,7 +43477,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PLANET-EATER LOOSE",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -43463,7 +43491,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Vox",
+                "Court",
+                "F11"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -43524,7 +43555,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Resolution",
+                "F11"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -43571,7 +43604,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "HEARTWORLD REFUGEES",
               "Description": "Psionic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -43585,7 +43618,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F11"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -43632,7 +43668,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "LOSTWORLD REFUGEES",
               "Description": "Relic",
               "GMNotes": "",
               "AltLookAngle": {
@@ -43646,7 +43682,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F11"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -43693,7 +43732,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "DEADWORLD REFUGEES",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -43707,7 +43746,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F11"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -43754,7 +43796,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "BLAZEWORLD REFUGEES",
               "Description": "Fuel",
               "GMNotes": "",
               "AltLookAngle": {
@@ -43768,7 +43810,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F11"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -43815,7 +43860,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "FORGEWORLD REFUGEES",
               "Description": "Material",
               "GMNotes": "",
               "AltLookAngle": {
@@ -43829,7 +43874,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F11"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -43876,7 +43924,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "PLANET HAMMER",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -43890,7 +43938,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Lore",
+                "Court",
+                "F11"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -43937,7 +43988,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "HAMMER FRAGMENTS / BREAKING WORLDS",
               "Description": "",
               "GMNotes": "",
               "AltLookAngle": {
@@ -43951,7 +44002,9 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Ability",
+                "F11"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -43998,7 +44051,7 @@
                 "scaleY": 1.0,
                 "scaleZ": 1.0
               },
-              "Nickname": "",
+              "Nickname": "SYCOPHANTS",
               "Description": "Weapon",
               "GMNotes": "",
               "AltLookAngle": {
@@ -44012,7 +44065,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Guild",
+                "Court",
+                "F11"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -44073,7 +44129,10 @@
                 "b": 0.713235259
               },
               "Tags": [
-                "Campaign Only"
+                "Campaign Only",
+                "Setup",
+                "Objective",
+                "F11"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -60280,7 +60339,7 @@
             "scaleY": 1.0,
             "scaleZ": 1.53204679
           },
-          "Nickname": "",
+          "Nickname": "PLANET BREAKER",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -60293,6 +60352,12 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "Campaign Only",
+            "Leader",
+            "Fate",
+            "F11"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -327,6 +327,22 @@
       {
         "displayed": "Title",
         "normalized": "title"
+      },
+      {
+        "displayed": "Ability",
+        "normalized": "ability"
+      },
+      {
+        "displayed": "Law",
+        "normalized": "law"
+      },
+      {
+        "displayed": "Objective",
+        "normalized": "objective"
+      },
+      {
+        "displayed": "Resolution",
+        "normalized": "resolution"
       }
     ]
   },

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -327,7 +327,7 @@
       {
         "displayed": "Title",
         "normalized": "title"
-      },
+      }
     ]
   },
   "Turns": {
@@ -60209,7 +60209,7 @@
       "DragSelectable": true,
       "Autoraise": true,
       "Sticky": true,
-      "Tooltip": true,
+      "Tooltip": false,
       "GridProjection": false,
       "HideWhenFaceDown": true,
       "Hands": false,
@@ -60281,7 +60281,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": true,
@@ -60344,7 +60344,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": true,
@@ -60407,7 +60407,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": true,
@@ -60470,7 +60470,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": true,
@@ -60533,7 +60533,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": true,
@@ -60596,7 +60596,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": true,
@@ -60659,7 +60659,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": true,
@@ -60722,7 +60722,7 @@
           "DragSelectable": true,
           "Autoraise": true,
           "Sticky": true,
-          "Tooltip": true,
+          "Tooltip": false,
           "GridProjection": false,
           "HideWhenFaceDown": false,
           "Hands": true,
@@ -61455,7 +61455,7 @@
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
-            "y": 0.0,f
+            "y": 0.0,
             "z": 0.0
           },
           "ColorDiffuse": {


### PR DESCRIPTION
Ref #47 

A lot of name additions + tagging.  There are some situations where being able to tooltip hover and reveal a card or token isn't ideal, while having a name on it is worthwhile.  In those cases I disabled tooltips for those cards/objects. 