### PR TITLE
Add camera control / timer menu

### DIFF
--- a/src/Camera.lua
+++ b/src/Camera.lua
@@ -77,7 +77,6 @@ end
 
 -- note that these onClick functions reference the wrapper functions in Global.lua
 function Camera.generateControlsXml(active_players, timer_running)
-    -- Generate camera control buttons
     return string.format([[
         <VerticalLayout spacing="10">
             <!-- Camera Controls in pairs -->
@@ -93,34 +92,30 @@ function Camera.generateControlsXml(active_players, timer_running)
             <!-- Player Timer Displays -->
             %s
 
-            <!-- Timer Controls at bottom -->
-            <HorizontalLayout spacing="5" padding="0 60 0 0">
-                <Button text="%s" id="playPauseButton" textColor="White" onClick="onPlayPauseTimer" width="30" flexibleWidth="0"/>
-                <Button text="Reset" id="resetTimer" textColor="Grey" onClick="resetTimer" width="55" fontStyle="Normal" tooltip="Reset all timers back to 0"/>
-            </HorizontalLayout>
+            %s
         </VerticalLayout>
     ]], Timer.generatePlayerTimerDisplays(active_players),
-        timer_running and "||" or "▶"
+        Timer.generateTimerControls(timer_running)
     )
 end
 
 function Camera.generateMenuXml(menuOpen, controlsXml)
     return string.format([[
         <Defaults>
-            <Button color="black" fontStyle="Bold" />
+            <Button color="black" fontSize="12" />
             <Button class="cameraControl" onClick="onCameraClick" />
         </Defaults>
 
         <VerticalLayout
             id="cameraLayout"
             height="320"
-            width="160"
+            width="100"
             allowDragging="true"
             returnToOriginalPositionWhenReleased="false"
             rectAlignment="UpperRight"
             anchorMin="1 1"
             anchorMax="1 1"
-            offsetXY="-5 -150"
+            offsetXY="-5 -250"
             spacing="5"
             childForceExpandHeight="false"
             childForceExpandWidth="true"
@@ -138,7 +133,7 @@ function Camera.generateMenuXml(menuOpen, controlsXml)
             <VerticalLayout
                 id="cameraControls"
                 height="320"
-                width="180"
+                width="100"
                 active="%s"
                 >
                 %s

--- a/src/Camera.lua
+++ b/src/Camera.lua
@@ -1,0 +1,150 @@
+local Timer = require("src/Timer")
+
+local Camera = {}
+
+-- note that these onClick functions are used by wrapper functions in Global.lua
+function Camera.onCourtClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=22.26, y=1.49, z=-1.65},
+        pitch = 70,
+        yaw = 90,
+        distance = 10
+    })
+end
+
+function Camera.onActionCardsClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=-14.0, y=1.49, z=-1.65},
+        pitch = 70,
+        yaw = 270,
+        distance = 12
+    })
+end
+
+function Camera.onDiceBoardClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=-33.2, y=1.07, z=-15.22},
+        pitch = 80,
+        yaw = 0,
+        distance = 18
+    })
+end
+
+function Camera.onMapClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=2.79, y=0.98, z=-1.35},
+        pitch = 70,
+        yaw = 0,
+        distance = 35
+    })
+end
+
+function Camera.onRedBoardClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=-10.6, y=1.48, z=14.92},
+        pitch = 80,
+        yaw = 0,
+        distance = 11
+    })
+end
+
+function Camera.onWhiteBoardClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=13.14, y=1.48, z=14.92},
+        pitch = 80,
+        yaw = 0,
+        distance = 11
+    })
+end
+
+function Camera.onYellowBoardClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=13.14, y=1.48, z=-16.12},
+        pitch = 80,
+        yaw = 0,
+        distance = 11
+    })
+end
+
+function Camera.onTealBoardClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=-10.6, y=1.48, z=-16.12},
+        pitch = 80,
+        yaw = 0,
+        distance = 11
+    })
+end
+
+-- note that these onClick functions reference the wrapper functions in Global.lua
+function Camera.generateControlsXml(active_players, timer_running)
+    -- Generate camera control buttons
+    return string.format([[
+        <VerticalLayout spacing="10">
+            <!-- Camera Controls in pairs -->
+            <HorizontalLayout spacing="5">
+                <Button text="Action" id="actionCardsCamera" textColor="Grey" onClick="onActionCardsClick" width="85"/>
+                <Button text="Court" id="courtCamera" textColor="Grey" onClick="onCourtClick" width="85"/>
+            </HorizontalLayout>
+            <HorizontalLayout spacing="5">
+                <Button text="Dice" id="diceCamera" textColor="Grey" onClick="onDiceBoardClick" width="85"/>
+                <Button text="Map" id="mapCamera" textColor="Grey" onClick="onMapClick" width="85"/>
+            </HorizontalLayout>
+
+            <!-- Player Timer Displays -->
+            %s
+
+            <!-- Timer Controls at bottom -->
+            <HorizontalLayout spacing="5" padding="0 60 0 0">
+                <Button text="%s" id="playPauseButton" textColor="White" onClick="onPlayPauseTimer" width="30" flexibleWidth="0"/>
+                <Button text="Reset" id="resetTimer" textColor="Grey" onClick="resetTimer" width="55" fontStyle="Normal" tooltip="Reset all timers back to 0"/>
+            </HorizontalLayout>
+        </VerticalLayout>
+    ]], Timer.generatePlayerTimerDisplays(active_players),
+        timer_running and "||" or "▶"
+    )
+end
+
+function Camera.generateMenuXml(menuOpen, controlsXml)
+    return string.format([[
+        <Defaults>
+            <Button color="black" fontStyle="Bold" />
+            <Button class="cameraControl" onClick="onCameraClick" />
+        </Defaults>
+
+        <VerticalLayout
+            id="cameraLayout"
+            height="320"
+            width="160"
+            allowDragging="true"
+            returnToOriginalPositionWhenReleased="false"
+            rectAlignment="UpperRight"
+            anchorMin="1 1"
+            anchorMax="1 1"
+            offsetXY="-5 -150"
+            spacing="5"
+            childForceExpandHeight="false"
+            childForceExpandWidth="true"
+            >
+            <Button
+                onClick="toggleCameraControls"
+                text="Camera Controls"
+                textColor="white"
+                color="Grey"
+                tooltip="Toggle camera controls / timer"
+                tooltipBackgroundColor="Grey"
+                tooltipTextColor="Black"
+                >
+            </Button>
+            <VerticalLayout
+                id="cameraControls"
+                height="320"
+                width="180"
+                active="%s"
+                >
+                %s
+            </VerticalLayout>
+        </VerticalLayout>
+    ]], tostring(menuOpen), controlsXml)
+end
+
+return Camera

--- a/src/Camera.lua
+++ b/src/Camera.lua
@@ -109,7 +109,7 @@ function Camera.generateMenuXml(menuOpen, controlsXml)
         <VerticalLayout
             id="cameraLayout"
             height="320"
-            width="100"
+            width="95"
             allowDragging="true"
             returnToOriginalPositionWhenReleased="false"
             rectAlignment="UpperRight"
@@ -133,7 +133,7 @@ function Camera.generateMenuXml(menuOpen, controlsXml)
             <VerticalLayout
                 id="cameraControls"
                 height="320"
-                width="100"
+                width="95"
                 active="%s"
                 >
                 %s

--- a/src/Camera.lua
+++ b/src/Camera.lua
@@ -95,7 +95,7 @@ function Camera.generateControlsXml(active_players, timer_running)
             %s
         </VerticalLayout>
     ]], Timer.generatePlayerTimerDisplays(active_players),
-        Timer.generateTimerControls(timer_running)
+        Timer.generateTimerControls(timer_running, active_players)
     )
 end
 

--- a/src/Camera.lua
+++ b/src/Camera.lua
@@ -115,7 +115,7 @@ function Camera.generateMenuXml(menuOpen, controlsXml)
             rectAlignment="UpperRight"
             anchorMin="1 1"
             anchorMax="1 1"
-            offsetXY="-5 -250"
+            offsetXY="-7 -250"
             spacing="5"
             childForceExpandHeight="false"
             childForceExpandWidth="true"

--- a/src/Control.lua
+++ b/src/Control.lua
@@ -128,6 +128,7 @@ function start_chapter()
     local initiative_player = Global.getVar("initiative_player")
     broadcastToAll(initiative_player .. " will start the chapter\n", initiative_player)
     Turns.turn_color = initiative_player
+    Global.call("startTimer")
 end
 
 function end_round()

--- a/src/Control.lua
+++ b/src/Control.lua
@@ -128,7 +128,6 @@ function start_chapter()
     local initiative_player = Global.getVar("initiative_player")
     broadcastToAll(initiative_player .. " will start the chapter\n", initiative_player)
     Turns.turn_color = initiative_player
-    Global.call("startTimer")
 end
 
 function end_round()

--- a/src/Global.lua
+++ b/src/Global.lua
@@ -1305,6 +1305,97 @@ function set_game_in_progress(params)
     -- end
 end
 
+
+-- Timer / camera control logic
+player_timers = {}
+timer_running = false
+timer_start_time = 0
+
+local timer_id = nil
+
+function startTimer()    
+    if timer_running then return end
+
+    if not Turns.turn_color or Turns.turn_color == "" then
+        broadcastToAll("No active turn - please use the turn system", {1, 0, 0})
+        return
+    end
+
+    if timer_id then
+        Wait.stop(timer_id)
+    end
+    
+    timer_running = true
+    timer_start_time = os.time()
+    timer_id = Wait.time(function() updateTimers() end, 1, -1)
+    loadCameraTimerMenu()
+end
+
+function formatTime(seconds)
+    local minutes = math.floor(seconds / 60)
+    seconds = seconds % 60
+    return string.format("%02d:%02d", minutes, seconds)
+end
+
+function pauseTimer()
+    if not timer_running then return end
+
+    timer_running = false
+
+    if timer_id then
+        Wait.stop(timer_id)
+        timer_id = nil
+    end
+    
+    loadCameraTimerMenu(true)
+end
+
+function resetTimer()
+    timer_running = false
+    timer_start_time = 0
+    for _, color in ipairs({"Red", "White", "Yellow", "Teal"}) do
+        player_timers[color] = 0
+        updateTimerDisplay(color)
+    end
+    if timer_id then
+        Wait.stop(timer_id)
+        timer_id = nil
+    end
+    
+    loadCameraTimerMenu(true)
+end
+
+function updateTimers()
+    if timer_running and Turns.turn_color then
+        -- Update the current player's total time
+        if not player_timers[Turns.turn_color] then
+            player_timers[Turns.turn_color] = 0
+        end
+        player_timers[Turns.turn_color] = player_timers[Turns.turn_color] + 1
+        
+        -- Update display for all players
+        for _, player in ipairs(active_players) do
+            local timerId = player.color:lower() .. "Timer"
+            updateTimerDisplay(player.color)
+            if player.color == Turns.turn_color then
+                UI.setAttribute(timerId, "fontStyle", "Bold")
+                UI.setAttribute(timerId, "fontSize", "18")
+            else
+                UI.setAttribute(timerId, "fontStyle", "Normal")
+                UI.setAttribute(timerId, "fontSize", "14")
+            end
+        end
+    end
+end
+
+function updateTimerDisplay(color)
+    local seconds = player_timers[color] or 0
+    local minutes = math.floor(seconds / 60)
+    seconds = seconds % 60
+    local display = string.format("%02d:%02d", minutes, seconds)
+    UI.setValue(color:lower() .. "Timer", display)
+end
+
 function onLoad()
 
     Initiative.add_menu()
@@ -1374,4 +1465,209 @@ function onLoad()
         face_up_discard_action_deck.interactable = false
         face_up_discard_action_deck.locked = false -- set this to false otherwise it breaks
     end
+
+    -- Initialize timers for all players
+    resetTimer()
+
+    Turns.enable = true
+    Turns.pass_turns = true
+    loadCameraTimerMenu(false)
+end
+
+function loadCameraTimerMenu(menuOpen)
+    -- if menuOpen is nil, leave the cameraControls active state alone
+    if menuOpen == nil then
+        menuOpen = UI.getAttribute("cameraControls", "active")
+    end
+
+    -- Generate camera control buttons
+    local controlsXml = string.format([[
+        <VerticalLayout spacing="10">
+            <!-- Camera Controls in pairs -->
+            <HorizontalLayout spacing="5">
+                <Button text="Action" id="actionCardsCamera" textColor="Grey" onClick="onActionCardsClick" width="85"/>
+                <Button text="Court" id="courtCamera" textColor="Grey" onClick="onCourtClick" width="85"/>
+            </HorizontalLayout>
+            <HorizontalLayout spacing="5">
+                <Button text="Dice" id="diceCamera" textColor="Grey" onClick="onDiceBoardClick" width="85"/>
+                <Button text="Map" id="mapCamera" textColor="Grey" onClick="onMapClick" width="85"/>
+            </HorizontalLayout>
+
+            <!-- Player Timer Displays -->
+            %s
+
+            <!-- Timer Controls at bottom -->
+            <HorizontalLayout spacing="5" padding="0 60 0 0">
+                <Button text="%s" id="playPauseButton" textColor="White" onClick="onPlayPauseTimer" width="30" flexibleWidth="0"/>
+                <Button text="Reset" id="resetTimer" textColor="Grey" onClick="resetTimer" width="55" fontStyle="Normal" tooltip="Reset all timers back to 0"/>
+            </HorizontalLayout>
+        </VerticalLayout>
+    ]], generatePlayerTimerDisplays(), 
+        timer_running and "||" or "▶"
+    )
+
+    -- toggle and overall menu position
+    local xml = string.format([[
+        <Defaults>
+            <Button color="black" fontStyle="Bold" />
+            <Button class="cameraControl" onClick="onCameraClick" />
+        </Defaults>
+
+        <VerticalLayout
+            id="cameraLayout"
+            height="320"
+            width="160"
+            allowDragging="true"
+            returnToOriginalPositionWhenReleased="false"
+            rectAlignment="UpperRight"
+            anchorMin="1 1"
+            anchorMax="1 1"
+            offsetXY="-5 -150"
+            spacing="5"
+            childForceExpandHeight="false"
+            childForceExpandWidth="true"
+            >
+            <Button
+                onClick="toggleCameraControls"
+                text="Camera Controls"
+                textColor="white"
+                color="Grey"
+                tooltip="Toggle camera controls / timer"
+                tooltipBackgroundColor="Grey"
+                tooltipTextColor="Black"
+                >
+            </Button>
+            <VerticalLayout
+                id="cameraControls"
+                height="320"
+                width="180"
+                active="%s"
+                >
+                %s
+            </VerticalLayout>
+        </VerticalLayout>
+    ]], tostring(menuOpen), controlsXml)
+
+    UI.setXml(xml)
+end
+
+function generatePlayerTimerDisplays()
+    local playerTimersXml = ""
+    local buttonColors = {
+        Red = "#FF0000",
+        White = "#FFFFFF",
+        Yellow = "#FFFF00",
+        Teal = "#00FFFF"
+    }
+
+    for _, player in ipairs(active_players) do
+        local isActive = player.color == Turns.turn_color
+        local currentTime = player_timers[player.color] or 0
+        local timeDisplay = formatTime(currentTime)
+        
+        playerTimersXml = playerTimersXml .. string.format(
+            [[<HorizontalLayout spacing="5">
+                <Text id="%sTimer" text="%s" color="%s" fontStyle="%s" preferredWidth="25" preferredHeight="13"/>
+                <Button text="%s" id="%sCamera" textColor="%s" onClick="on%sBoardClick" preferredWidth="29"/>
+            </HorizontalLayout>]],
+            player.color:lower(),
+            timeDisplay,
+            buttonColors[player.color],
+            isActive and "Bold" or "Normal",
+            player.color,
+            player.color:lower(),
+            buttonColors[player.color],
+            player.color
+        )
+    end
+    
+    return playerTimersXml
+end
+
+function onPlayPauseTimer(player, value, id)
+    if timer_running then
+        pauseTimer()
+    else
+        startTimer()
+    end
+    -- Update button state
+    loadCameraTimerMenu(true)
+end
+
+
+function toggleCameraControls(player, value, id)
+    local isOpen = UI.getAttribute("cameraControls", "active") == "true"
+    loadCameraTimerMenu(not isOpen)
+end
+
+function onMapClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=2.79, y=0.98, z=-1.35},
+        pitch = 70,
+        yaw = 0,
+        distance = 35
+    })
+end
+
+function onCourtClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=22.26, y=1.49, z=-1.65},
+        pitch = 70,
+        yaw = 90,
+        distance = 10
+    })
+end
+
+function onActionCardsClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=-14.0, y=1.49, z=-1.65},
+        pitch = 70,
+        yaw = 270,
+        distance = 12
+    })
+end
+
+function onDiceBoardClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=-33.2, y=1.07, z=-15.22},
+        pitch = 80,
+        yaw = 0,
+        distance = 18
+    })
+end
+
+function onRedBoardClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=-10.6, y=1.48, z=14.92},
+        pitch = 80,
+        yaw = 0,
+        distance = 11
+    })
+end
+
+function onWhiteBoardClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=13.14, y=1.48, z=14.92},
+        pitch = 80,
+        yaw = 0,
+        distance = 11
+    })
+end
+
+function onYellowBoardClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=13.14, y=1.48, z=-16.12},
+        pitch = 80,
+        yaw = 0,
+        distance = 11
+    })
+end
+
+function onTealBoardClick(player, value, id)
+    Player[player.color].lookAt({
+        position = {x=-10.6, y=1.48, z=-16.12},
+        pitch = 80,
+        yaw = 0,
+        distance = 11
+    })
 end

--- a/src/Timer.lua
+++ b/src/Timer.lua
@@ -100,7 +100,7 @@ function Timer.generatePlayerTimerDisplays(active_players)
         playerTimersXml = playerTimersXml .. string.format(
             [[<HorizontalLayout spacing="5">
                 <Text id="%sTimer" text="%s" color="%s" fontStyle="%s" preferredWidth="25" preferredHeight="13"/>
-                <Button text="%s" id="%sCamera" textColor="%s" onClick="on%sBoardClick" preferredWidth="29"/>
+                <Button text="%s" id="%sCamera" textColor="%s" onClick="on%sBoardClick" preferredWidth="28"/>
             </HorizontalLayout>]],
             player.color:lower(),
             timeDisplay,
@@ -114,6 +114,16 @@ function Timer.generatePlayerTimerDisplays(active_players)
     end
     
     return playerTimersXml
+end
+
+function Timer.generateTimerControls(timer_running)
+    return string.format([[
+        <!-- Timer Controls at bottom -->
+        <HorizontalLayout spacing="5" padding="0 45 0 0">
+            <Button text="%s" id="playPauseButton" textColor="White" onClick="onPlayPauseTimer" width="30" flexibleWidth="0"/>
+            <Button text="↺" id="resetTimer" textColor="Grey" onClick="resetTimer" width="30" fontStyle="Normal" tooltip="Reset all timers back to 0"/>
+        </HorizontalLayout>
+    ]], timer_running and "||" or "▶")
 end
 
 return Timer

--- a/src/Timer.lua
+++ b/src/Timer.lua
@@ -116,7 +116,12 @@ function Timer.generatePlayerTimerDisplays(active_players)
     return playerTimersXml
 end
 
-function Timer.generateTimerControls(timer_running)
+function Timer.generateTimerControls(timer_running, active_players)
+    -- Only show timer controls if there are 2 or more players
+    if not active_players or #active_players < 2 then
+        return ""
+    end
+
     return string.format([[
         <!-- Timer Controls at bottom -->
         <HorizontalLayout spacing="5" padding="0 45 0 0">

--- a/src/Timer.lua
+++ b/src/Timer.lua
@@ -99,7 +99,7 @@ function Timer.generatePlayerTimerDisplays(active_players)
         
         playerTimersXml = playerTimersXml .. string.format(
             [[<HorizontalLayout spacing="5">
-                <Text id="%sTimer" text="%s" color="%s" fontStyle="%s" preferredWidth="25" preferredHeight="13"/>
+                <Text id="%sTimer" text="%s" color="%s" fontSize="12" fontStyle="%s" preferredWidth="25" preferredHeight="13"/>
                 <Button text="%s" id="%sCamera" textColor="%s" onClick="on%sBoardClick" preferredWidth="28"/>
             </HorizontalLayout>]],
             player.color:lower(),

--- a/src/Timer.lua
+++ b/src/Timer.lua
@@ -46,6 +46,7 @@ function Timer.reset()
         Timer.player_timers[color] = 0
         Timer.updateDisplay(color)
     end
+    UI.setValue("totalTime", Timer.formatTime(0))
     if Timer.timer_id then
         Wait.stop(Timer.timer_id)
         Timer.timer_id = nil
@@ -72,6 +73,8 @@ function Timer.update(active_players)
                 UI.setAttribute(timerId, "fontSize", "12")
             end
         end
+
+        UI.setValue("totalTime", Timer.formatTime(Timer.getTotalTime()))
     end
 end
 
@@ -116,6 +119,14 @@ function Timer.generatePlayerTimerDisplays(active_players)
     return playerTimersXml
 end
 
+function Timer.getTotalTime()
+    local total = 0
+    for _, color in ipairs({"Red", "White", "Yellow", "Teal"}) do
+        total = total + (Timer.player_timers[color] or 0)
+    end
+    return total
+end
+
 function Timer.generateTimerControls(timer_running, active_players)
     -- Only show timer controls if there are 2 or more players
     if not active_players or #active_players < 2 then
@@ -124,11 +135,12 @@ function Timer.generateTimerControls(timer_running, active_players)
 
     return string.format([[
         <!-- Timer Controls at bottom -->
-        <HorizontalLayout spacing="5" padding="0 45 0 0">
+        <HorizontalLayout spacing="5">
+            <Text id="totalTime" text="%s" color="#808080" fontSize="12" preferredWidth="25" preferredHeight="13"/>
             <Button text="%s" id="playPauseButton" textColor="White" onClick="onPlayPauseTimer" width="30" flexibleWidth="0"/>
             <Button text="↺" id="resetTimer" textColor="Grey" onClick="resetTimer" width="30" fontStyle="Normal" tooltip="Reset all timers back to 0"/>
         </HorizontalLayout>
-    ]], timer_running and "||" or "▶")
+    ]], Timer.formatTime(Timer.getTotalTime()), timer_running and "||" or "▶")
 end
 
 return Timer

--- a/src/Timer.lua
+++ b/src/Timer.lua
@@ -66,10 +66,10 @@ function Timer.update(active_players)
             Timer.updateDisplay(player.color)
             if player.color == Turns.turn_color then
                 UI.setAttribute(timerId, "fontStyle", "Bold")
-                UI.setAttribute(timerId, "fontSize", "18")
+                UI.setAttribute(timerId, "fontSize", "16")
             else
                 UI.setAttribute(timerId, "fontStyle", "Normal")
-                UI.setAttribute(timerId, "fontSize", "14")
+                UI.setAttribute(timerId, "fontSize", "12")
             end
         end
     end


### PR DESCRIPTION
This supersedes #43, which includes a turn timer that is revealed alongside the camera control buttons to jump to each player's board.  As of now I have the timer kick off by default at Start Chapter, but it can be paused or the menu closed.  

Marking this a work-in-progress while playtesting until I can move some functions into a Timer.lua or Camera.lua for better organization. That said I'm still running into issues with moving XML and UI related functions outside of Global scope.

https://www.reddit.com/r/Arcs/comments/1gylqm9/arcs_on_tabletop_simulator_outlaw_edition/ I'm using an alternate workshop item to playtest work-in-progress changes before they get merged in here.