### PR TITLE
Add missing court tag to lore deck

### DIFF
--- a/TS_Save.json
+++ b/TS_Save.json
@@ -75733,7 +75733,8 @@
         "b": 0.713235259
       },
       "Tags": [
-        "Lore"
+        "Lore",
+        "Court"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,


### PR DESCRIPTION
This lacking tag was preventing the lore decks from mixing during leaders & lore setup.