### PR TITLE
fix deleting objective prior to is_campaign being decided

### DIFF
--- a/src/ArcsPlayer.lua
+++ b/src/ArcsPlayer.lua
@@ -123,7 +123,7 @@ function ArcsPlayer.components_visibility(color, is_visible, is_campaign)
     for key, id in pairs(player_pieces[color]["components"]) do
         if (key == "cities") then
             ArcsPlayer._show_cities(color, is_visible)
-        elseif (key == "objective" and not is_campaign) then
+        elseif (key == "objective" and is_visible and not is_campaign) then
             local obj = getObjectFromGUID(id)
             if (obj) then
                 obj.destroy()

--- a/src/Campaign.lua
+++ b/src/Campaign.lua
@@ -92,7 +92,7 @@ function Campaign.setup(with_leaders, with_ll_expansion)
 
     local active_player_colors = {}
     for _, p in pairs(active_players) do
-        ArcsPlayer.setup(p, false)
+        ArcsPlayer.setup(p, true)
         table.insert(active_player_colors, p.color)
     end
 


### PR DESCRIPTION
I didn't realize the ArcsPlayer setup was being executed before the setup menu selection for base game or campaign.... deleting the objectives before is_campaign is even decided on.  Since is_visible is false during the initial mod load, the newly updated condition should no longer delete the objectives immediately after load.

Additionally, the campaign setup invocation of ArcsPlayer.setup was passing is_campaign false... 

Make sure you load a fresh TS_Save before applying this after merge.  (The TS_Save state that is applied to the workshop currently has the objectives deleted already).  