### PR TITLE
Fix teal miniature agent names

### DIFF
--- a/TS_Save.json
+++ b/TS_Save.json
@@ -94253,7 +94253,7 @@
             "scaleY": 0.3250005,
             "scaleZ": 0.3250005
           },
-          "Nickname": "Yellow Agent",
+          "Nickname": "Teal Agent",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -94323,7 +94323,7 @@
             "scaleY": 0.3250005,
             "scaleZ": 0.3250005
           },
-          "Nickname": "Yellow Agent",
+          "Nickname": "Teal Agent",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -94393,7 +94393,7 @@
             "scaleY": 0.3250005,
             "scaleZ": 0.3250005
           },
-          "Nickname": "Yellow Agent",
+          "Nickname": "Teal Agent",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -94463,7 +94463,7 @@
             "scaleY": 0.3250005,
             "scaleZ": 0.3250005
           },
-          "Nickname": "Yellow Agent",
+          "Nickname": "Teal Agent",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -94533,7 +94533,7 @@
             "scaleY": 0.3250005,
             "scaleZ": 0.3250005
           },
-          "Nickname": "Yellow Agent",
+          "Nickname": "Teal Agent",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -94603,7 +94603,7 @@
             "scaleY": 0.3250005,
             "scaleZ": 0.3250005
           },
-          "Nickname": "Yellow Agent",
+          "Nickname": "Teal Agent",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -94673,7 +94673,7 @@
             "scaleY": 0.3250005,
             "scaleZ": 0.3250005
           },
-          "Nickname": "Yellow Agent",
+          "Nickname": "Teal Agent",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -94743,7 +94743,7 @@
             "scaleY": 0.3250005,
             "scaleZ": 0.3250005
           },
-          "Nickname": "Yellow Agent",
+          "Nickname": "Teal Agent",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -94813,7 +94813,7 @@
             "scaleY": 0.3250005,
             "scaleZ": 0.3250005
           },
-          "Nickname": "Yellow Agent",
+          "Nickname": "Teal Agent",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {
@@ -94883,7 +94883,7 @@
             "scaleY": 0.3250005,
             "scaleZ": 0.3250005
           },
-          "Nickname": "Yellow Agent",
+          "Nickname": "Teal Agent",
           "Description": "",
           "GMNotes": "",
           "AltLookAngle": {


### PR DESCRIPTION
The new miniature agents still have "Yellow Agent" names, causing "return to supply" to direct them into the yellow supply.  This corrects that.