### PR TITLE
fix: event cards getting pulled out of face up discard deck

### DIFF
--- a/TS_Save.json
+++ b/TS_Save.json
@@ -37186,7 +37186,8 @@
               "Tags": [
                 "Campaign Only",
                 "Action",
-                "F5"
+                "F5",
+                "Event"
               ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
@@ -72603,7 +72604,7 @@
         "scaleY": 1.0,
         "scaleZ": 1.0
       },
-      "Nickname": "",
+      "Nickname": "Event Deck",
       "Description": "",
       "GMNotes": "",
       "AltLookAngle": {
@@ -72684,7 +72685,8 @@
           },
           "Tags": [
             "Action",
-            "Campaign Only"
+            "Campaign Only",
+            "Event"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -72809,7 +72811,8 @@
           },
           "Tags": [
             "Action",
-            "Campaign Only"
+            "Campaign Only",
+            "Event"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74090,7 +74093,7 @@
           "XmlUI": ""
         },
         {
-          "GUID": "204545",
+          "GUID": "fe7a80",
           "Name": "Card",
           "Transform": {
             "posX": -25.3357868,
@@ -74118,7 +74121,8 @@
           },
           "Tags": [
             "Action",
-            "Campaign Only"
+            "Campaign Only",
+            "Event"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -74884,7 +74888,7 @@
           "XmlUI": ""
         },
         {
-          "GUID": "3c30a1",
+          "GUID": "eff76c",
           "Name": "Card",
           "Transform": {
             "posX": -16.05392,
@@ -74912,7 +74916,8 @@
           },
           "Tags": [
             "Action",
-            "Campaign Only"
+            "Campaign Only",
+            "Event"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
@@ -75068,7 +75073,7 @@
           "XmlUI": ""
         },
         {
-          "GUID": "73c5ff",
+          "GUID": "39a322",
           "Name": "Card",
           "Transform": {
             "posX": -53.1018,
@@ -75095,7 +75100,9 @@
             "b": 0.713235259
           },
           "Tags": [
-            "Action"
+            "Action",
+            "Campaign Only",
+            "Event"
           ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,

--- a/src/ActionCards.lua
+++ b/src/ActionCards.lua
@@ -53,7 +53,10 @@ local face_up_discard_guids = {
     ["Mobilization 4"] = "8f521a",
     ["Mobilization 5"] = "bcf2e7",
     ["Mobilization 6"] = "7981dc",
-    ["Mobilization 7"] = "864dd1"
+    ["Mobilization 7"] = "864dd1",
+    ["Event"] = "fe7a80",
+    ["Event"] = "eff76c",
+    ["Event"] = "39a322"
 }
 
 function ActionCards.get_action_deck()
@@ -192,6 +195,7 @@ function ActionCards.to_face_up_discard(card)
             discarded_card = fud_discard_action_deck.takeObject({
                 guid = v.guid
             })
+            break
         end
     end
 


### PR DESCRIPTION
While looking into #122 I added missing event tags and adjusted some of the GUIDs used for event cards in the face up discard deck, those changes ended up not being associated with the fix but I'll leave them in as it shouldn't hurt anything and our tagging consistency is improved by it.

The real fix is adding a break to ActionCards.to_face_up_discard(), what was happening is since the Action Card description for all 3 event cards is simply "Event", the loop would execute the following 3 times:
```
discarded_card = fud_discard_action_deck.takeObject({
                guid = v.guid
            })
```
1 card would get placed in the face up discard area, the other two would sit near/above the face up discard pile and become visible.

Now we break the loop as soon as we find 1 match on the card description. 