### PR TITLE
fix end_round handling

### DIFF
--- a/src/Control.lua
+++ b/src/Control.lua
@@ -102,13 +102,13 @@ local toggle_auto_end_params = {
     function_owner = self,
     click_function = "toggle_auto_end",
     label = "Toggle\nAuto\nEnd",
-    tooltip = "Toggle Auto End Round.\n\nPlease report any problems to the Steam Workshop or Github page",
+    tooltip = "Toggle Auto End Round.\n\nDisabled for now, feature is in progress",
     height = 260,
     width = 220,
     position = {0.6, 0.5, -0.01},
     font_size = 50,
-    color = {0.2, 0.5, 0.2},
-    hover_color = {0.34, 0.48, 0.34}
+    color = {0.5, 0.5, 0.5},
+    hover_color = {0.4, 0.4, 0.4}
 }
 
 function onload()
@@ -170,18 +170,18 @@ function toggle_auto_end()
     Global.setVar("is_auto_end_round_enabled", toggle)
 
     if (toggle) then
-        local GREEN = {0.2, 0.5, 0.2}
+        local GREEN = {0.5, 0.5, 0.5}
         self.editButton({
             index = 5,
             color = GREEN,
-            hover_color = {0.34, 0.48, 0.34}
+            hover_color = {0.4, 0.4, 0.4}
         })
     else
-        local RED = {0.8, 0.3, 0.2}
+        local RED = {0.3, 0.3, 0.3}
         self.editButton({
             index = 5,
             color = RED,
-            hover_color = {0.48, 0.34, 0.34}
+            hover_color = {0.2, 0.2, 0.2}
         })
     end
 end

--- a/src/Global.lua
+++ b/src/Global.lua
@@ -226,23 +226,6 @@ function onPlayerAction(player, action, targets)
     end
 end
 
-function onPlayerTurn(player, previous_player)
-    if previous_player == nil then
-        print(player.color .. " is going first. It's now their turn.")
-    else
-        print(previous_player.color .. "'s turn is over. It's now " ..
-                  player.color .. "'s turn.")
-    end
-
-    turn_count = turn_count + 1
-    if is_auto_end_round_enabled then
-        if turn_count > #getSeatedPlayers() then
-            RoundManager.endRound() -- turn count is reset within RoundManager.endRound()
-        end
-    end
-
-end
-
 function onObjectEnterZone(zone, object)
     Counters.update(zone)
 

--- a/src/RoundManager.lua
+++ b/src/RoundManager.lua
@@ -24,9 +24,12 @@ function RoundManager.endRound()
     local initiative_player = Global.getVar("initiative_player")
     local all_players = Global.getVar("active_players")
 
-    if Initiative then
+    if not initiative_player then
         broadcastToAll(
-            "\n\n!!Could not determine initiative player!!\nPlease ensure initiative marker is near a player board.\n\n")
+            "\n\n!! Could not determine initiative player !!\n" ..
+            "Ensure initiative marker is near the top right snap point of a player board.\n" ..
+            "Or have the expected player click 'Take Initiative'\n",
+            Color.Red)
     elseif Initiative.is_seized() and seize_detected then
         -- Someone already manually seized initiative
         Initiative.unseize()


### PR DESCRIPTION
Marking the auto end round as grey/disabled on the toggle button, for now

Removing the global onPlayerTurn, the turn by turn messaging is a bit excessive IMO, as there are already player name + color call outs in chat, these are somewhat duplicate and also out of order compared to the built-in messaging.

Fixed the "if Initiative then" which was forcing all of the end round logic to not occur, blocking surpass, seize detection, and initiative handling. 

