### PR TITLE
Multiple fixes

### DIFF
--- a/TS_Save.json
+++ b/TS_Save.json
@@ -24425,13 +24425,13 @@
       "Transform": {
         "posX": -10.0,
         "posY": 3.536803,
-        "posZ": -0.656739235,
+        "posZ": 1.04660344,
         "rotX": 0.0,
         "rotY": 0.0,
         "rotZ": 0.0,
         "scaleX": 0.25,
         "scaleY": 5.1,
-        "scaleZ": 10.9162855
+        "scaleZ": 7.5
       },
       "Nickname": "Seize Zone",
       "Description": "",

--- a/TS_Save.json
+++ b/TS_Save.json
@@ -37171,7 +37171,7 @@
                 "scaleZ": 1.0
               },
               "Nickname": "Action Card",
-              "Description": "Event",
+              "Description": "Event 0",
               "GMNotes": "",
               "AltLookAngle": {
                 "x": 0.0,
@@ -72671,7 +72671,7 @@
             "scaleZ": 1.0
           },
           "Nickname": "Action Card",
-          "Description": "Event",
+          "Description": "Event 0",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -72734,7 +72734,7 @@
             "scaleZ": 1.0
           },
           "Nickname": "Action Card",
-          "Description": "Event",
+          "Description": "Event 0",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -72797,7 +72797,7 @@
             "scaleZ": 1.0
           },
           "Nickname": "Action Card",
-          "Description": "Event",
+          "Description": "Event 0",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -74107,7 +74107,7 @@
             "scaleZ": 1.0
           },
           "Nickname": "Action Card",
-          "Description": "Event",
+          "Description": "Event 0",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -74902,7 +74902,7 @@
             "scaleZ": 1.0
           },
           "Nickname": "Action Card",
-          "Description": "Event",
+          "Description": "Event 0",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,
@@ -75087,7 +75087,7 @@
             "scaleZ": 1.0
           },
           "Nickname": "Action Card",
-          "Description": "Event",
+          "Description": "Event 0",
           "GMNotes": "",
           "AltLookAngle": {
             "x": 0.0,

--- a/src/AmbitionMarkers.lua
+++ b/src/AmbitionMarkers.lua
@@ -135,9 +135,6 @@ function ambitionMarkers:display_undo_button()
     })
 end
 
-function ambitionMarkers.declare(obj, player_color)
-
-end
 
 function ambitionMarkers:undo()
     broadcastToAll("Undo Ambition Declaration")

--- a/src/Global.lua
+++ b/src/Global.lua
@@ -240,7 +240,7 @@ function onObjectEnterZone(zone, object)
                 player:set_last_played_seize_card(object.getDescription())
                 broadcastToAll(player.color .. " is seizing the initiative",
                     player.color)
-            elseif (zone.guid == played_zone.guid) then
+            elseif (object.is_face_up and zone.guid == played_zone.guid) then
                 player:set_last_played_action_card(object.getDescription())
             end
 

--- a/src/Global.lua
+++ b/src/Global.lua
@@ -110,6 +110,7 @@ active_ambitions = {
     b0b4d0 = ""
 }
 
+zoneWaits = {}
 ----------------------------------------------------
 AmbitionMarkers = require("src/AmbitionMarkers")
 local ActionCards = require("src/ActionCards")
@@ -146,6 +147,19 @@ function update_player_scores()
     end
 end
 
+function isObjectInZone(object, zone)
+    if not object or not zone then return false end
+    
+    -- Revert to loop-based implementation since containsObject isn't working
+    local zoneObjects = zone.getObjects()
+    for _, obj in ipairs(zoneObjects) do
+        if obj.guid == object.guid then
+            return true
+        end
+    end
+    return false
+end
+
 function onObjectDrop(player_color, object)
     local object_name = object.getName()
 
@@ -157,12 +171,6 @@ function onObjectDrop(player_color, object)
             player:update_score()
         end, 0.5)
     end
-
-
-    local played_zone = getObjectFromGUID(action_card_zone_GUID)
-    local played_zone_card = false
-    local seize_zone = getObjectFromGUID(seize_zone_GUID)
-    local seize_zone_card = false
 
     -- Action card tracking
     if object and object.tag == "Card" and object.hasTag("Action") then
@@ -178,17 +186,14 @@ function onObjectDrop(player_color, object)
                                 Turns.turn_color)
             end
 
-            for _, zone_obj in ipairs(seize_zone.getObjects()) do
-                if (zone_obj.guid == object.guid) then
-                    seize_zone_card = true
-                end
-            end
+            local played_zone_card = false
+            local played_zone = getObjectFromGUID(action_card_zone_GUID)
+            local seize_zone_card = false
+            local seize_zone = getObjectFromGUID(seize_zone_GUID)
+
+            seize_zone_card = isObjectInZone(object, seize_zone)
             if not seize_zone_card then
-                for _, zone_obj in ipairs(played_zone.getObjects()) do
-                    if (zone_obj.guid == object.guid) then
-                        played_zone_card = true
-                    end
-                end
+                played_zone_card = isObjectInZone(object, played_zone)
             end
 
             if (object.is_face_down and seize_zone_card) then
@@ -206,7 +211,7 @@ function onObjectDrop(player_color, object)
 
     -- ambitions
     if (object_name == "Ambition") then
-
+        -- commenting until we can get the ambition markers working
         -- Wait.time(function()
         --     AmbitionMarkers.get_ambition_info(object)
         -- end, 0.5)


### PR DESCRIPTION
- TS_Save changes: Moves the face-up discard deck away from the game board, players can accidentally drop their action cards into the deck and lose the card. #132   I've also shrunken the size of the seize zone so that it does apply for lead cards.  And added a "0" to event card descriptions, otherwise face up discard handling breaks when event cards get played in campaign mode.
- Global.setVar("active_ambitions", global_ambitions) to prevent an error during game load #130 
- Removed ambitionMarkers.declare for now
- 
- I moved the new waitZones implementation back towards onObjectDrop rather than onObjectEnterZone since there are situations where when a player flips a card that has already been played on the action row, onObjectEnterZone does not trigger (and the set_last_played_card state becomes inaccurate).
- Also fixed a missing condition which was broadcasting the card information when played face down (when face up discard was active).
- Commented out an onObjectDrop condition for ambition markers, which is causing #130