### PR TITLE
move song of freedom if it enters the discard

### DIFF
--- a/src/CourtDiscard.lua
+++ b/src/CourtDiscard.lua
@@ -17,13 +17,24 @@ function onObjectEnterZone(zone, object)
         end
     end
 
+    -- Check if the object is "SONG OF FREEDOM" and move it 4 units to the right
+    if object.getName() == "SONG OF FREEDOM" then
+        local currentPosition = object.getPosition()
+        object.setPosition({
+            x = currentPosition.x + 4,
+            y = currentPosition.y,
+            z = currentPosition.z
+        })
+        return
+    end
+
     -- if a deck object has yet to form, record the newest card entering discard
     if #courtCards == 3 then 
         courtDiscardTopCard = object
         return
     end
 
-    -- handle situations where a deck object has not yet formed but a third cards enters discard
+    -- handle situations where a deck object has not yet formed but a third card enters discard
     -- we pull the last discarded card from a newly formed deck, place it back on top of the discard pile
     if courtDiscardTopCard and courtDiscardDeck then 
         Wait.time(function()


### PR DESCRIPTION
This moves song of freedom if it enters the discard making sure it never stays in there. This is one of the most forgotten rules in my games so I think it'd be a good change. I think this is better than directly putting it back in the court deck since if someone puts it there accidentally it shouldn't instantly shuffle.