### PR TITLE
keep the draw bottom card face down until it reaches the hand

### DIFF
--- a/src/ActionCards.lua
+++ b/src/ActionCards.lua
@@ -369,11 +369,15 @@ end
 function ActionCards.draw_bottom(player_color, position, object)
     local hand_zone = Player[player_color].getHandTransform()
     local deck = ActionCards.get_action_deck()
-    deck.takeObject({
+    local drawn_card = deck.takeObject({
         top = false,
         position = hand_zone.position,
-        rotation = hand_zone.rotation + Vector({0, 180, 0})
+        rotation = hand_zone.rotation + Vector({0, 180, 180})
     })
+    -- wait .75 seconds and flip it face up
+    Wait.time(function()
+        drawn_card.setRotation(Vector({0, 180, 0}))
+    end, 0.75)
 end
 
 function ActionCards.faceup_discard_visibility(show)


### PR DESCRIPTION
Due to the delay + distance for the card to travel to the player's hand, it is partially revealed when it is close to the player's hand.  Notably this is easier to spot for yellow and teal given the distance from each hand zone to where the action discard deck resides.  This adds a delay so that it stays face down while it travels to the player's hand, and then flips face up.  

#149 