### PR TITLE
Fix oop bug

### DIFF
--- a/src/BaseGame.lua
+++ b/src/BaseGame.lua
@@ -449,6 +449,8 @@ function BaseGame.setupOutOfPlayClusters(setup_card)
                 image = component.img
             })
             object.setLock(true)
+
+            object.setPosition({object.getPosition().x, 0.93, object.getPosition().z})
         end
     end
 

--- a/src/Global.lua
+++ b/src/Global.lua
@@ -24,7 +24,7 @@ oop_components = {
         Sector = {
             pos = {-0.16, 0.97, -1.02},
             rot = {0, 180, -0.01},
-            scale = {2.48, 0.1, 2.48},
+            scale = {2.48, 1, 2.48},
             img = "http://cloud-3.steamusercontent.com/ugc/2313225941445769502/1D85B9468BB538D788FCF7576A05606918CD0DD4/"
         },
         Gate = {
@@ -37,7 +37,7 @@ oop_components = {
         Sector = {
             pos = {-0.50, 0.97, -0.64},
             rot = {0, 180, -0.01},
-            scale = {2.48, 0.1, 2.48},
+            scale = {2.48, 1, 2.48},
             img = "http://cloud-3.steamusercontent.com/ugc/2313225941445769605/A40A0C79B27F1F1C45E0570E46BA8A7B253F356E/"
         },
         Gate = {
@@ -50,7 +50,7 @@ oop_components = {
         Sector = {
             pos = {-0.45, 0.97, 0.73},
             rot = {0, 179.99, -0.01},
-            scale = {2.36, 0.1, 2.36},
+            scale = {2.36, 1, 2.36},
             img = "http://cloud-3.steamusercontent.com/ugc/2313225941445769710/C408A11914F7F4DEA83686851730DDF10A8BD5D4/"
         },
         Gate = {
@@ -63,7 +63,7 @@ oop_components = {
         Sector = {
             pos = {0.17, 0.97, 0.90},
             rot = {0, 179, -0.01},
-            scale = {2.54, 0.1, 2.54},
+            scale = {2.54, 1, 2.54},
             img = "http://cloud-3.steamusercontent.com/ugc/2313225941445769816/0AA42154550040133E7D6740F85CD487D5F6967B/"
         },
         Gate = {
@@ -76,7 +76,7 @@ oop_components = {
         Sector = {
             pos = {0.5, 0.97, 0.55},
             rot = {0, 179.99, -0.01},
-            scale = {2.48, 0.1, 2.48},
+            scale = {2.48, 1, 2.48},
             img = "http://cloud-3.steamusercontent.com/ugc/2313225941445770194/8600421030523070B8E2F05CECC3281DF24989AC/"
         },
         Gate = {
@@ -89,7 +89,7 @@ oop_components = {
         Sector = {
             pos = {0.46, 0.97, -0.82},
             rot = {0, 180.00, -0.01},
-            scale = {2.29, 0.1, 2.29},
+            scale = {2.29, 1, 2.29},
             img = "http://cloud-3.steamusercontent.com/ugc/2313225941445770362/76677A077FC1D6CD3672DCC036646ABFD2881F62/"
         },
         Gate = {


### PR DESCRIPTION
A prior commit introduced #137 , which was attempted to handle situations where 2 player resource stacks were not flat on the board due to the thickness of the overlays.

Now we retain the original thickness, but instead recede the custom overlay tokens into the main board.  Thanks @Laurens1234 for replicating and finding the fix.

![card_overlay](https://github.com/user-attachments/assets/7a1e7e4b-03e6-4a85-bdd3-67b0d3f379f3)
